### PR TITLE
created calculation entries for all system entries. create calc/sys r…

### DIFF
--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -648,19 +648,15 @@ class GromacsParser:
             n_evaluations = self.energy_parser.length
 
         calculation_times_ps = thermo_data.get('Time')
-        calculation_steps = [int((val / time_step).magnitude) for val in calculation_times_ps]
         calculation_times_ps = calculation_times_ps.magnitude * ureg.convert(
             1.0, calculation_times_ps.units, ureg.picosecond)
 
-        system_indices_assigned = []
+        flag_system_time_map = False if not self._system_time_map else True
         for n in range(n_evaluations):
             sec_scc = sec_run.m_create(Calculation)
-            system_index = self._system_time_map.get(
-                round(calculation_times_ps[n], 5)) if calculation_times_ps[n] is not None else None
-            if system_index is None:
-                system_index = self._system_step_map.get(calculation_steps[n])
+            system_index = self._system_time_map.pop(
+                round(calculation_times_ps[n], 5), None) if calculation_times_ps[n] is not None else None
             if system_index is not None:
-                system_indices_assigned.append(system_index)
                 sec_scc.forces = Forces(total=ForcesEntry(value=self.traj_parser.get_forces(system_index)))
                 sec_scc.system_ref = sec_system[system_index]
                 sec_scc.method_ref = sec_run.method[-1] if sec_run.method else None
@@ -693,7 +689,7 @@ class GromacsParser:
                     sec_energy.contributions.append(
                         EnergyEntry(kind=self._metainfo_mapping[key], value=val))
 
-        if not self._system_step_map and not self._system_time_map:
+        if not flag_system_time_map:
             if n_evaluations == len(sec_system):
                 for i_calc, calc in enumerate(sec_run.calculation):
                     calc.system_ref = sec_system[i_calc]
@@ -701,20 +697,14 @@ class GromacsParser:
                                     'Assuming correspondence and creating references between these two lists.')
                 return
 
-        for n in range(len(sec_system)):
-            if n not in system_indices_assigned:
-                sec_scc = sec_run.m_create(Calculation)
-                sec_scc.time = self._system_info[n]['time']
-                sec_scc.step = self._system_info[n]['step']
+        for time, n in self._system_time_map.items():
+            sec_scc = sec_run.m_create(Calculation)
+            sec_scc.time = time
+            sec_scc.step = int((time / time_step).magnitude)
 
         times = [calc.time for calc in sec_run.calculation]
-        steps = [calc.step for calc in sec_run.calculation]
         if None not in times:
             calculations_sorted = [[calc.time.magnitude, calc] for calc in sec_run.calculation]
-            calculations_sorted = sorted(calculations_sorted, key=lambda x: x[0], reverse=False)
-            sec_run.calculation = [calc[1] for calc in calculations_sorted]
-        elif None not in steps:
-            calculations_sorted = [[calc.step, calc] for calc in sec_run.calculation]
             calculations_sorted = sorted(calculations_sorted, key=lambda x: x[0], reverse=False)
             sec_run.calculation = [calc[1] for calc in calculations_sorted]
         else:
@@ -732,24 +722,15 @@ class GromacsParser:
 
         pbc = self.log_parser.get_pbc()
         self._system_time_map = {}
-        self._system_step_map = {}
-        self._system_info = []
         for n in range(n_frames):
             if (n % self.frame_rate) > 0:
                 continue
             positions = self.traj_parser.get_positions(n)
             sec_system = sec_run.m_create(System)
             time = self.traj_parser.get_time(n)  # TODO Physical times should not be stored for GeometryOpt
-            time_step = self.log_parser.get('input_parameters', {}).get('dt', 1.0) * ureg.ps
             if time is not None:
                 self._system_time_map[round(ureg.convert(
                     time.magnitude, time.units, ureg.picosecond), 5)] = len(self._system_time_map)
-                step = int((ureg.convert(
-                    time.magnitude, time.units,
-                    time_step.units) / time_step.magnitude) + 1e-6) if time_step else None
-                if step is not None:
-                    self._system_step_map[step] = len(self._system_step_map)
-            self._system_info.append({'time': time, 'step': step})
             if positions is None:
                 continue
 

--- a/atomisticparsers/lammps/parser.py
+++ b/atomisticparsers/lammps/parser.py
@@ -672,15 +672,11 @@ class LammpsParser:
             val.magnitude * ureg.convert(1.0, val.units, ureg.picosecond)
             for val in calculation_times_ps] if type(time_step) != float else [None] * len(calculation_times_ps)
 
-        system_indices_assigned = []
+        flag_system_step_map = False if not self._system_step_map else True
         for n in range(n_thermo):
             sec_scc = sec_run.m_create(Calculation)
-            system_index = self._system_time_map.get(
-                round(calculation_times_ps[n], 5)) if calculation_times_ps[n] is not None else None
-            if system_index is None:
-                system_index = self._system_step_map.get(calculation_steps[n])
+            system_index = self._system_step_map.pop(calculation_steps[n], None)
             if system_index is not None:
-                system_indices_assigned.append(system_index)
                 sec_scc.forces = Forces(total=ForcesEntry(value=self.traj_parsers.eval('get_forces', system_index)))
                 sec_scc.system_ref = sec_system[system_index]
             sec_scc.method_ref = sec_run.method[-1] if sec_run.method else None
@@ -704,7 +700,7 @@ class LammpsParser:
                 elif key == 'cpu':
                     sec_scc.time_calculation = float(val[n])
 
-        if not self._system_step_map and not self._system_time_map:
+        if not flag_system_step_map:
             if n_thermo == len(sec_system):
                 for i_calc, calc in enumerate(sec_run.calculation):
                     calc.system_ref = sec_system[i_calc]
@@ -712,18 +708,13 @@ class LammpsParser:
                                     'Assuming correspondence and creating references between these two lists.')
                 return
 
-        for n in range(len(sec_system)):
-            if n not in system_indices_assigned:
-                sec_scc = sec_run.m_create(Calculation)
-                sec_scc.time = self._system_info[n]['time']
-                sec_scc.step = self._system_info[n]['step']
+        for step, n in self._system_step_map.items():
+            sec_scc = sec_run.m_create(Calculation)
+            sec_scc.step = step
+            sec_scc.time = step * time_step
 
-        times = [calc.time for calc in sec_run.calculation]
         steps = [calc.step for calc in sec_run.calculation]
-        if None not in times:
-            calculations_sorted = [[calc.time.magnitude, calc] for calc in sec_run.calculation]
-            calculations_sorted = sorted(calculations_sorted, key=lambda x: x[0], reverse=False)
-        elif None not in steps:
+        if None not in steps:
             calculations_sorted = [[calc.step, calc] for calc in sec_run.calculation]
             calculations_sorted = sorted(calculations_sorted, key=lambda x: x[0], reverse=False)
             sec_run.calculation = [calc[1] for calc in calculations_sorted]
@@ -1115,9 +1106,7 @@ class LammpsParser:
             formula = ''.join([f'{name}({count})' for name, count in zip(*children_count_tup)])
             return formula
 
-        self._system_time_map = {}
         self._system_step_map = {}
-        self._system_info = []
         for i in range(n_frames):
             if (i % self.frame_rate) > 0:
                 continue
@@ -1125,15 +1114,8 @@ class LammpsParser:
             sec_system = sec_run.m_create(System)
             step = self.traj_parsers.eval('get_step', i)  # TODO Physical times should not be stored for GeometryOpt
             step = int(step) if step is not None else None
-            time_step = self.get_time_step()
-            time = None
             if step is not None:
                 self._system_step_map[step] = len(self._system_step_map)
-                time = step * time_step if time_step else None
-                if (time is not None) and (not isinstance(time, float)):
-                    self._system_time_map[round(ureg.convert(
-                        time.magnitude, time.units, ureg.picosecond), 5)] = len(self._system_time_map)
-            self._system_info.append({'time': time, 'step': step})
 
             sec_atoms = sec_system.m_create(Atoms)
             sec_atoms.n_atoms = self.traj_parsers.eval('get_n_atoms', i)

--- a/atomisticparsers/lammps/parser.py
+++ b/atomisticparsers/lammps/parser.py
@@ -632,7 +632,7 @@ class LammpsParser:
             'e_tail': 'van der Waals long range', 'kineng': 'kinetic', 'poteng': 'potential'}
         self._frame_rate = None
         # max cumulative number of atoms for all parsed trajectories to calculate sampling rate
-        self._cum_max_atoms = 10000000
+        self._cum_max_atoms = 2500000
 
     @property
     def frame_rate(self):
@@ -664,64 +664,44 @@ class LammpsParser:
         if not thermo_data:
             return
 
-        n_thermo = len(thermo_data.get('Step', []))
         calculation_steps = thermo_data.get('Step')
         calculation_steps = [int(val) if val is not None else None for val in calculation_steps]
-        calculation_times_ps = [val * time_step for val in calculation_steps]
-        calculation_times_ps = [
-            val.magnitude * ureg.convert(1.0, val.units, ureg.picosecond)
-            for val in calculation_times_ps] if type(time_step) != float else [None] * len(calculation_times_ps)
 
-        flag_system_step_map = False if not self._system_step_map else True
-        for n in range(n_thermo):
+        step_map = {}
+        for i_calc, calculation_step in enumerate(calculation_steps):
+            system_index = self._system_step_map.pop(calculation_steps[i_calc], None)
+            step_map[calculation_step] = {'system_index': system_index, 'calculation_index': i_calc}
+        for step, i_sys in self._system_step_map.items():
+            step_map[step] = {'system_index': i_sys, 'calculation_index': None}
+
+        for step in sorted(step_map):
             sec_scc = sec_run.m_create(Calculation)
-            system_index = self._system_step_map.pop(calculation_steps[n], None)
+            sec_scc.step = step
+            sec_scc.time = sec_scc.step * time_step  # TODO Physical times should not be stored for GeometryOpt
+            sec_scc.method_ref = sec_run.method[-1] if sec_run.method else None
+
+            system_index = step_map[step]['system_index']
             if system_index is not None:
                 sec_scc.forces = Forces(total=ForcesEntry(value=self.traj_parsers.eval('get_forces', system_index)))
                 sec_scc.system_ref = sec_system[system_index]
-            sec_scc.method_ref = sec_run.method[-1] if sec_run.method else None
 
-            sec_energy = sec_scc.m_create(Energy)
-            for key, val in thermo_data.items():
-                key = key.lower()
-                if key in self._energy_mapping:
-                    sec_energy.contributions.append(
-                        EnergyEntry(kind=self._energy_mapping[key], value=val[n]))
-                elif key == 'toteng':
-                    sec_energy.current = EnergyEntry(value=val[n])
-                    sec_energy.total = EnergyEntry(value=val[n])
-                elif key == 'press':
-                    sec_scc.pressure = val[n]
-                elif key == 'temp':
-                    sec_scc.temperature = val[n]
-                elif key == 'step':
-                    sec_scc.step = int(val[n])
-                    sec_scc.time = sec_scc.step * time_step
-                elif key == 'cpu':
-                    sec_scc.time_calculation = float(val[n])
-
-        if not flag_system_step_map:
-            if n_thermo == len(sec_system):
-                for i_calc, calc in enumerate(sec_run.calculation):
-                    calc.system_ref = sec_system[i_calc]
-                self.logger.warning('Time and step information not available, but system and calculation are the same length.'
-                                    'Assuming correspondence and creating references between these two lists.')
-                return
-
-        for step, n in self._system_step_map.items():
-            sec_scc = sec_run.m_create(Calculation)
-            sec_scc.step = step
-            sec_scc.time = step * time_step
-
-        steps = [calc.step for calc in sec_run.calculation]
-        if None not in steps:
-            calculations_sorted = [[calc.step, calc] for calc in sec_run.calculation]
-            calculations_sorted = sorted(calculations_sorted, key=lambda x: x[0], reverse=False)
-            sec_run.calculation = [calc[1] for calc in calculations_sorted]
-
-            sec_run.calculation = [calc[1] for calc in calculations_sorted]
-        else:
-            self.logger.warning('Time and step information not available in section calculation, entries may be out of order.')
+            calculation_index = step_map[step]['calculation_index']
+            if calculation_index is not None:
+                sec_energy = sec_scc.m_create(Energy)
+                for key, val in thermo_data.items():
+                    key = key.lower()
+                    if key in self._energy_mapping:
+                        sec_energy.contributions.append(
+                            EnergyEntry(kind=self._energy_mapping[key], value=val[calculation_index]))
+                    elif key == 'toteng':
+                        sec_energy.current = EnergyEntry(value=val[calculation_index])
+                        sec_energy.total = EnergyEntry(value=val[calculation_index])
+                    elif key == 'press':
+                        sec_scc.pressure = val[calculation_index]
+                    elif key == 'temp':
+                        sec_scc.temperature = val[calculation_index]
+                    elif key == 'cpu':
+                        sec_scc.time_calculation = float(val[calculation_index])
 
     def parse_workflow(self):
         sec_workflow = self.archive.m_create(Workflow)

--- a/atomisticparsers/lammps/parser.py
+++ b/atomisticparsers/lammps/parser.py
@@ -655,7 +655,7 @@ class LammpsParser:
 
     def parse_thermodynamic_data(self):
         sec_run = self.archive.run[-1]
-        # sec_system = sec_run.system
+        sec_system = sec_run.system
 
         time_step = self.get_time_step()
         thermo_data = self.log_parser.get_thermodynamic_data()
@@ -672,6 +672,7 @@ class LammpsParser:
             val.magnitude * ureg.convert(1.0, val.units, ureg.picosecond)
             for val in calculation_times_ps] if type(time_step) != float else [None] * len(calculation_times_ps)
 
+        system_indices_assigned = []
         for n in range(n_thermo):
             sec_scc = sec_run.m_create(Calculation)
             system_index = self._system_time_map.get(
@@ -679,8 +680,9 @@ class LammpsParser:
             if system_index is None:
                 system_index = self._system_step_map.get(calculation_steps[n])
             if system_index is not None:
+                system_indices_assigned.append(system_index)
                 sec_scc.forces = Forces(total=ForcesEntry(value=self.traj_parsers.eval('get_forces', system_index)))
-                sec_scc.system_ref = sec_run.system[system_index]
+                sec_scc.system_ref = sec_system[system_index]
             sec_scc.method_ref = sec_run.method[-1] if sec_run.method else None
 
             sec_energy = sec_scc.m_create(Energy)
@@ -701,6 +703,34 @@ class LammpsParser:
                     sec_scc.time = sec_scc.step * time_step
                 elif key == 'cpu':
                     sec_scc.time_calculation = float(val[n])
+
+        if not self._system_step_map and not self._system_time_map:
+            if n_thermo == len(sec_system):
+                for i_calc, calc in enumerate(sec_run.calculation):
+                    calc.system_ref = sec_system[i_calc]
+                self.logger.warning('Time and step information not available, but system and calculation are the same length.'
+                                    'Assuming correspondence and creating references between these two lists.')
+                return
+
+        for n in range(len(sec_system)):
+            if n not in system_indices_assigned:
+                sec_scc = sec_run.m_create(Calculation)
+                sec_scc.time = self._system_info[n]['time']
+                sec_scc.step = self._system_info[n]['step']
+
+        times = [calc.time for calc in sec_run.calculation]
+        steps = [calc.step for calc in sec_run.calculation]
+        if None not in times:
+            calculations_sorted = [[calc.time.magnitude, calc] for calc in sec_run.calculation]
+            calculations_sorted = sorted(calculations_sorted, key=lambda x: x[0], reverse=False)
+        elif None not in steps:
+            calculations_sorted = [[calc.step, calc] for calc in sec_run.calculation]
+            calculations_sorted = sorted(calculations_sorted, key=lambda x: x[0], reverse=False)
+            sec_run.calculation = [calc[1] for calc in calculations_sorted]
+
+            sec_run.calculation = [calc[1] for calc in calculations_sorted]
+        else:
+            self.logger.warning('Time and step information not available in section calculation, entries may be out of order.')
 
     def parse_workflow(self):
         sec_workflow = self.archive.m_create(Workflow)
@@ -1087,20 +1117,23 @@ class LammpsParser:
 
         self._system_time_map = {}
         self._system_step_map = {}
+        self._system_info = []
         for i in range(n_frames):
             if (i % self.frame_rate) > 0:
                 continue
 
             sec_system = sec_run.m_create(System)
-            sec_system.step = self.traj_parsers.eval('get_step', i)  # TODO Physical times should not be stored for GeometryOpt
-            sec_system.step = int(sec_system.step) if sec_system.step is not None else None
+            step = self.traj_parsers.eval('get_step', i)  # TODO Physical times should not be stored for GeometryOpt
+            step = int(step) if step is not None else None
             time_step = self.get_time_step()
-            if sec_system.step is not None:
-                self._system_step_map[sec_system.step] = len(self._system_step_map)
-                sec_system.time = sec_system.step * time_step if time_step else None
-                if sec_system.time is not None:
+            time = None
+            if step is not None:
+                self._system_step_map[step] = len(self._system_step_map)
+                time = step * time_step if time_step else None
+                if (time is not None) and (not isinstance(time, float)):
                     self._system_time_map[round(ureg.convert(
-                        sec_system.time.magnitude, sec_system.time.units, ureg.picosecond), 5)] = len(self._system_time_map)
+                        time.magnitude, time.units, ureg.picosecond), 5)] = len(self._system_time_map)
+            self._system_info.append({'time': time, 'step': step})
 
             sec_atoms = sec_system.m_create(Atoms)
             sec_atoms.n_atoms = self.traj_parsers.eval('get_n_atoms', i)

--- a/atomisticparsers/utils/mdanalysis.py
+++ b/atomisticparsers/utils/mdanalysis.py
@@ -302,15 +302,6 @@ class MDAnalysisParser(FileParser):
         # MDAnalysis assumes no change in atom configuration
         return [guess_atom_element(name) for name in self.get('atoms_info', {}).get('names', [])]
 
-    # def get_time_step(self, frame_index):
-    #     '''
-    #     Returns the integer time step of the frame with index frame_index.
-    #     '''
-    #     frame = self.get_frame(frame_index)
-    #     tmp = frame.dt
-    #     tmp2 = frame.time
-    #     return int(frame.time / frame.dt) if frame is not None else None
-
     def get_time(self, frame_index):
         '''
         Returns the elapsed simulated physical time since the start of the simulation for index frame_index.


### PR DESCRIPTION
…eference for equal lengths in case time/step info not available

Calculation list now contains entries for every member of system, regardless if corresponding calculation info exists. The matching is the same as before (based on time or step info). The final calculation list is sorted by time or step info if available.

In case there is no time or step info available, there are two possible cases:
1. system and calculation have the same length: then the references are created assuming correspondence and a warning is given.
2. system and calculation have different lengths: then the missing system entries are appended to the calculation list and a warning is given that the list may not be in order.