### PR TITLE
Remove workflow schema from nomad

### DIFF
--- a/atomisticparsers/amber/metainfo/amber.py
+++ b/atomisticparsers/amber/metainfo/amber.py
@@ -23,6 +23,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -169,7 +170,7 @@ class System(simulation.system.System):
         ''')
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/asap/metainfo/asap.py
+++ b/atomisticparsers/asap/metainfo/asap.py
@@ -22,13 +22,13 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     MSection, MCategory, Category, Package, Quantity, Section, SubSection, SectionProxy,
     Reference
 )
-from nomad.datamodel.metainfo.simulation import workflow
+import simulationworkflowschema
 
 
 m_package = Package()
 
 
-class MolecularDynamics(workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 
@@ -54,7 +54,7 @@ class MolecularDynamics(workflow.MolecularDynamics):
         ''')
 
 
-class GeometryOptimization(workflow.GeometryOptimization):
+class GeometryOptimization(simulationworkflowschema.GeometryOptimization):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/asap/parser.py
+++ b/atomisticparsers/asap/parser.py
@@ -27,8 +27,8 @@ from nomad.parsing.file_parser import FileParser
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import (
     Method, ForceField, Model)
-from nomad.datamodel.metainfo.simulation.workflow import (
-    GeometryOptimization, GeometryOptimizationMethod,
+from simulationworkflowschema import (
+    GeometryOptimization, GeometryOptimizationMethod
 )
 from atomisticparsers.utils import MDParser
 from .metainfo.asap import MolecularDynamics  # pylint: disable=unused-import

--- a/atomisticparsers/bopfox/parser.py
+++ b/atomisticparsers/bopfox/parser.py
@@ -31,7 +31,7 @@ from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, Energy, EnergyEntry, Forces, ForcesEntry, Stress, StressEntry, Charges,
     ChargesValue
 )
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     GeometryOptimization, GeometryOptimizationMethod, SinglePoint
 )
 from atomisticparsers.utils import MDParser

--- a/atomisticparsers/dlpoly/metainfo/dl_poly.py
+++ b/atomisticparsers/dlpoly/metainfo/dl_poly.py
@@ -23,6 +23,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference, JSON
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -69,7 +70,7 @@ class x_dl_poly_section_md_topology(MSection):
         repeats=True)
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/gromacs/metainfo/gromacs.py
+++ b/atomisticparsers/gromacs/metainfo/gromacs.py
@@ -22,6 +22,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     MSection, MCategory, Category, Package, Quantity, Section, SubSection, SectionProxy
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -1572,7 +1573,7 @@ class System(simulation.system.System):
         ''',)
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True,)
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -39,7 +39,7 @@ from nomad.datamodel.metainfo.simulation.method import (
 from nomad.datamodel.metainfo.simulation.system import (
     AtomsGroup
 )
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     GeometryOptimization, GeometryOptimizationMethod, GeometryOptimizationResults
 )
 from .metainfo.gromacs import x_gromacs_section_control_parameters, x_gromacs_section_input_output_files

--- a/atomisticparsers/gromos/metainfo/gromos.py
+++ b/atomisticparsers/gromos/metainfo/gromos.py
@@ -23,6 +23,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -1388,7 +1389,7 @@ class System(simulation.system.System):
         ''')
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/gulp/metainfo/gulp.py
+++ b/atomisticparsers/gulp/metainfo/gulp.py
@@ -24,6 +24,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -827,7 +828,7 @@ class Calculation(simulation.calculation.Calculation):
     x_gulp_bulk_optimisation = SubSection(sub_section=x_gulp_bulk_optimisation.m_def)
 
 
-class ElasticResults(simulation.workflow.ElasticResults):
+class ElasticResults(simulationworkflowschema.ElasticResults):
 
     m_def = Section(validate=False, extends_base_section=True)
 
@@ -909,7 +910,7 @@ class ElasticResults(simulation.workflow.ElasticResults):
         ''')
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/gulp/parser.py
+++ b/atomisticparsers/gulp/parser.py
@@ -35,7 +35,7 @@ from nomad.datamodel.metainfo.simulation.system import (
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, Energy, EnergyEntry
 )
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     Elastic, ElasticMethod, ElasticResults, MolecularDynamics, MolecularDynamicsMethod
 )
 from atomisticparsers.gulp.metainfo.gulp import x_gulp_bulk_optimisation, x_gulp_bulk_optimisation_cycle

--- a/atomisticparsers/lammps/metainfo/lammps.py
+++ b/atomisticparsers/lammps/metainfo/lammps.py
@@ -23,6 +23,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -99,7 +100,7 @@ class System(simulation.system.System):
         ''')
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/lammps/parser.py
+++ b/atomisticparsers/lammps/parser.py
@@ -31,7 +31,7 @@ from nomad.datamodel.metainfo.simulation.method import (
 from nomad.datamodel.metainfo.simulation.system import (
     AtomsGroup
 )
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     GeometryOptimization, GeometryOptimizationMethod, GeometryOptimizationResults
 )
 from .metainfo.lammps import x_lammps_section_input_output_files, x_lammps_section_control_parameters

--- a/atomisticparsers/namd/metainfo/namd.py
+++ b/atomisticparsers/namd/metainfo/namd.py
@@ -23,6 +23,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference, JSON
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -1006,7 +1007,7 @@ class System(simulation.system.System):
         ''')
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/namd/parser.py
+++ b/atomisticparsers/namd/parser.py
@@ -27,7 +27,7 @@ from nomad.datamodel import EntryArchive
 from nomad.parsing.file_parser import TextParser, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run, Program
 from nomad.datamodel.metainfo.simulation.method import Method
-from nomad.datamodel.metainfo.simulation.workflow import MolecularDynamics
+from simulationworkflowschema import MolecularDynamics
 from atomisticparsers.utils import MDAnalysisParser, MDParser
 from .metainfo import m_env  # pylint: disable=unused-import
 

--- a/atomisticparsers/tinker/metainfo/tinker.py
+++ b/atomisticparsers/tinker/metainfo/tinker.py
@@ -22,6 +22,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference, JSON
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -778,7 +779,7 @@ class System(simulation.system.System):
         ''')
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 
@@ -872,7 +873,7 @@ class MolecularDynamics(simulation.workflow.MolecularDynamics):
         ''')
 
 
-class GeometryOptimization(simulation.workflow.GeometryOptimization):
+class GeometryOptimization(simulationworkflowschema.GeometryOptimization):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/tinker/parser.py
+++ b/atomisticparsers/tinker/parser.py
@@ -34,7 +34,7 @@ from nomad.datamodel.metainfo.simulation.method import (
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, Energy, EnergyEntry, VibrationalFrequencies
 )
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     GeometryOptimization, GeometryOptimizationMethod
 )
 from atomisticparsers.utils import MDAnalysisParser, MDParser

--- a/atomisticparsers/utils/parsers.py
+++ b/atomisticparsers/utils/parsers.py
@@ -28,7 +28,7 @@ from nomad.metainfo import MSection, SubSection, Quantity
 from nomad.datamodel.metainfo.simulation.run import Run
 from nomad.datamodel.metainfo.simulation.system import System
 from nomad.datamodel.metainfo.simulation.calculation import Calculation
-from nomad.datamodel.metainfo.simulation.workflow import MolecularDynamics
+from simulationworkflowschema import MolecularDynamics
 from nomad.datamodel.metainfo.simulation.method import Interaction
 
 

--- a/atomisticparsers/xtb/metainfo/xtb.py
+++ b/atomisticparsers/xtb/metainfo/xtb.py
@@ -22,6 +22,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Package, Quantity, Section, SubSection, JSON
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -87,7 +88,7 @@ class MultipolesEntry(simulation.calculation.MultipolesEntry):
         ''')
 
 
-class GeometryOptimization(simulation.workflow.GeometryOptimization):
+class GeometryOptimization(simulationworkflowschema.GeometryOptimization):
 
     m_def = Section(validate=False, extends_base_section=True)
 
@@ -146,7 +147,7 @@ class GeometryOptimization(simulation.workflow.GeometryOptimization):
         ''')
 
 
-class MolecularDynamics(simulation.workflow.MolecularDynamics):
+class MolecularDynamics(simulationworkflowschema.MolecularDynamics):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/atomisticparsers/xtb/parser.py
+++ b/atomisticparsers/xtb/parser.py
@@ -31,7 +31,7 @@ from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.calculation import (
     Calculation, ScfIteration, Energy, EnergyEntry, BandEnergies, Multipoles, MultipolesEntry
 )
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     SinglePoint, GeometryOptimization, GeometryOptimizationMethod
 )
 from atomisticparsers.utils import MDParser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [{ name = "The NOMAD Authors" }]
 license = { file = "LICENSE" }
 dependencies = [
     'nomad-lab[infrastructure]@git+https://github.com/nomad-coe/nomad.git@develop',
+    "nomad-schema-plugin-simulation-workflow@git+https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow.git@develop",
     'lxml==4.7.1',
     'MDAnalysis',
     'panedr==0.2',


### PR DESCRIPTION
Simulation workflow schema are moved to a plug in https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow. References to the old schema are removed.