### PR TITLE
139 visualize systems with topology information only

### DIFF
--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -820,9 +820,9 @@ class GromacsParser(MDParser):
         edr_file = self.get_gromacs_file('edr')
         if edr_file:
             # If the edr file can't be read or there are no keys, an error will be raised by the energy parser
+            self.energy_parser.mainfile = edr_file
             try:
                 self.energy_parser.keys()
-                self.energy_parser.mainfile = edr_file
                 thermo_data = self.energy_parser
             except Exception:
                 thermo_data = None
@@ -849,6 +849,9 @@ class GromacsParser(MDParser):
         self.thermodynamics_steps = [
             int(time / time_step if time_step else 1) for time in calculation_times
         ]
+        if not self.thermodynamics_steps:
+            self.logger.error('No thermodynamic data can be found.')
+            return
 
         for n, step in enumerate(self.thermodynamics_steps):
             data = {
@@ -1647,7 +1650,7 @@ class GromacsParser(MDParser):
 
             return primary_file
 
-        # Enumerate over copy of list to avoid skipping elements
+        # Iterate over copy of list to avoid skipping elements
         for ext in self.traj_file_priority_list[:]:
             traj_file = _get_traj_file(ext)
             if traj_file:

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1695,7 +1695,9 @@ class GromacsParser(MDParser):
         """
         traj_priority_list = ['trr', 'xtc', 'pdb', 'gro']
 
-        def is_readable(file_path):
+        # Check if the number of particles in the current trajectory file matches
+        # the number of particles in self.mainfile (topology).
+        def matches_mainfile(file_path):
             positions = None
             try:
                 test_universe = MDAnalysis.Universe(
@@ -1713,18 +1715,20 @@ class GromacsParser(MDParser):
 
             return False
 
-        # sort all entries in self.gromacs_files by priority_list and filename match
+        # Sort all entries in self.gromacs_files by priority_list and filename match,
+        # return matching trajectory with highest priority.
         fallback_files = []
         for file_ext in traj_priority_list:
             results = self.get_all_gromacs_files(file_ext)
             if results:
                 traj_files_list = [*results.get(0, []), *results.get(1, [])]
                 for file_path in traj_files_list:
-                    if is_readable(file_path):
+                    if matches_mainfile(file_path):
                         return [file_path]
                 fallback_files.extend(results.get(2, []))
+        # return the first match from fallback_files only if no higher-priority match was found
         for file_path in fallback_files:
-            if is_readable(file_path):
+            if matches_mainfile(file_path):
                 return [file_path]
         return []
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -774,50 +774,11 @@ class GromacsParser(MDParser):
 
         return self.get_gromacs_file(self.mdp_ext)
 
-    def get_gromacs_file(self, ext, return_all=False):
+    def get_gromacs_file(self, ext):
         files = [d for d in self._gromacs_files if d.endswith(ext)]
 
         if len(files) == 0:
             return ''
-
-        if return_all:
-            all_files = {}
-            contain_basename, no_basename_match, counts = [], [], []
-            for f in files:
-                # We assume that the matching trajectory file has (or starts with)
-                # the same basename as the log file, e.g., out.log would correspond to
-                # out.tpr and out.trr and out.edr (or out_some.tpr ...).
-                # These files are therefore given first (second... ) priority in the dictionary.
-                if f.rsplit('.', 1)[0] == self._basename:
-                    all_files[0] = {0: os.path.join(self._maindir, f)}
-                elif f.rsplit('.', 1)[0].startswith(self._basename):
-                    contain_basename.append(os.path.join(self._maindir, f))
-                else:
-                    # if potential files are named differently, we guess that the ones with a unique name
-                    # would be the files we are more likely interested in, and sort the results accordingly
-                    count = 0
-                    for reff in self._gromacs_files:
-                        if f.rsplit('.', 1)[0] == reff.rsplit('.', 1)[0]:
-                            count += 1
-                    counts.append(count)
-                    no_basename_match.append(os.path.join(self._maindir, f))
-            # add the files starting with the same basename in the order they were encountered
-            if contain_basename:
-                all_files[1] = {
-                    idx: file_path for idx, file_path in enumerate(contain_basename)
-                }
-            # sort files with the correct format, but different basename:
-            # according to the number of other files with the same name
-            # (fewer files with same name: higher priority)
-            if no_basename_match:
-                all_files[2] = {
-                    idx: file_path
-                    for idx, file_path in enumerate(
-                        [x for _, x in sorted(zip(counts, no_basename_match))]
-                    )
-                }
-
-            return all_files
 
         if len(files) == 1:
             return os.path.join(self._maindir, files[0])
@@ -844,13 +805,48 @@ class GromacsParser(MDParser):
                 if f.rsplit('.', 1)[0] == reff.rsplit('.', 1)[0]:
                     count += 1
             if count == 1:
-                if return_all:
-                    all_files.extend(os.path.join(self._maindir, f))
-                else:
-                    return os.path.join(self._maindir, f)
+                return os.path.join(self._maindir, f)
             counts.append(count)
 
         return os.path.join(self._maindir, files[counts.index(min(counts))])
+
+    def get_all_gromacs_files(self, ext):
+        files = [d for d in self._gromacs_files if d.endswith(ext)]
+
+        if len(files) == 0:
+            return ''
+
+        all_files = {}
+        contain_basename, no_basename_match, counts = [], [], []
+        for f in files:
+            # We assume that the matching trajectory file has (or starts with)
+            # the same basename as the log file, e.g., out.log would correspond to
+            # out.tpr and out.trr and out.edr (or out_some.tpr ...).
+            # These files are therefore given first (second... ) priority in the dictionary.
+            if f.rsplit('.', 1)[0] == self._basename:
+                all_files[0] = [os.path.join(self._maindir, f)]
+            # ? `a in b` or `b.startswith(a) or b.endswith(a)`? How generic/specific do we want to be?
+            elif self._basename in f.rsplit('.', 1)[0]:
+                contain_basename.append(os.path.join(self._maindir, f))
+            else:
+                # if potential files are named differently, we guess that the ones with a unique name
+                # would be the files we are more likely interested in, and sort the results accordingly
+                count = 0
+                for reff in self._gromacs_files:
+                    if f.rsplit('.', 1)[0] == reff.rsplit('.', 1)[0]:
+                        count += 1
+                counts.append(count)
+                no_basename_match.append(os.path.join(self._maindir, f))
+        # add the files starting with the same basename in the order they were encountered
+        if contain_basename:
+            all_files[1] = contain_basename
+        # sort files with the correct format, but different basename:
+        # according to the number of other files with the same name
+        # (fewer files with same name: higher priority)
+        if no_basename_match:
+            all_files[2] = [x for _, x in sorted(zip(counts, no_basename_match))]
+
+        return all_files
 
     def parse_thermodynamic_data(self):
         sec_run = self.archive.run[-1]
@@ -1685,8 +1681,13 @@ class GromacsParser(MDParser):
     def find_trajectory_files(self):
         """
         Find and set trajectory files following the priority:
-        "trr" > "xtc", fall back "pdb" > "gro".
-        Prioritize files with exact basename match over files with partial basename match over other files.
+        "trr" > "xtc", fallback "pdb" > "gro". Prioritize files with exact basename
+        match over files with partial basename match with the same extension.
+        Test other files only if no true trajectory format with exact or partial
+        basename match is found.
+
+        Example: out.log -> out.trr > out_1.trr > 2_out.trr > out.xtc > ... > out.pdb > out.gro
+
         """
         traj_priority_list = ['trr', 'xtc', 'pdb', 'gro']
 
@@ -1708,48 +1709,20 @@ class GromacsParser(MDParser):
 
             return False
 
-        def sort_by_priority(files_dicts):
-            # accounting for multiple files starting with the basename (priority 1)
-            # we expect each dict to contain the exact basename match (priority 0)
-            n_keys = [len(d[1]) if d.get(1) else 0 for d in files_dicts]
-            m_keys = [len(d[2]) if d.get(2) else 0 for d in files_dicts]
-            seen_keys = []
-            dicts_list = []
-            n_add = 1
-            m_add = sum(n_keys) + 1
-            for d_idx, d in enumerate(files_dicts):
-                for key in d:
-                    if key == 1:
-                        d[key] = {idx + n_add: val for idx, val in d[key].items()}
-                        n_add += n_keys[d_idx]
-                    if key == 2:
-                        d[key] = {idx + m_add: val for idx, val in d[key].items()}
-                        m_add += m_keys[d_idx]
-                    dicts_list.append(d.get(key, None))
-                    for idx in d[key].keys():
-                        if idx not in seen_keys:
-                            seen_keys.append(idx)
-            # make sure the returned list is sorted by our priority order
-            sorted_values = [
-                d.get(key, None) for key in sorted(seen_keys) for d in dicts_list
-            ]
-            # remove None values from not present files
-            sorted_values = list(filter(lambda x: x is not None, sorted_values))
-
-            return sorted_values
-
         # sort all entries in self.gromacs_files by priority_list and filename match
-        traj_files_list = []
-        for p in traj_priority_list:
-            results = self.get_gromacs_file(p, return_all=True)
-            # if files with the correct extension are found, add to the list
+        fallback_files = []
+        for file_ext in traj_priority_list:
+            results = self.get_all_gromacs_files(file_ext)
             if results:
-                traj_files_list.append(results)
-        if traj_files_list:
-            traj_files_list = sort_by_priority(traj_files_list)
-            for file_path in traj_files_list:
-                if is_readable(file_path):
-                    return [file_path]
+                traj_files_list = [*results.get(0, []), *results.get(1, [])]
+                for file_path in traj_files_list:
+                    if is_readable(file_path):
+                        print(file_path)
+                        return [file_path]
+                fallback_files.extend(results.get(2, []))
+        for file_path in fallback_files:
+            if is_readable(file_path):
+                return [file_path]
         return []
 
     def write_to_archive(self):

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -363,6 +363,8 @@ class GromacsEDRParser(FileParser):
         self._results[key] = val
 
     def keys(self):
+        if self.fileedr is None:
+            return []
         return list(self.fileedr.keys())
 
     @property
@@ -860,19 +862,10 @@ class GromacsParser(MDParser):
         # TODO read also from ene
         # Make sure *.edr file is part of upload before attempting to parse it.
         edr_file = self.get_gromacs_file('edr')
-        thermo_data = None
         if edr_file:
-            # If the edr file can't be read or there are no keys, an error will be raised by the energy parser
+            self.energy_parser.keys()
             self.energy_parser.mainfile = edr_file
-            try:
-                self.energy_parser.keys()
-                thermo_data = self.energy_parser
-            except Exception:
-                self.logger.error('Error reading edr file.')
-            # self.energy_parser.mainfile = edr_file
-            # self.energy_parser.keys()
-            # thermo_data = self.energy_parser
-
+            thermo_data = self.energy_parser
         if not thermo_data:
             # try to get it from log file
             steps = self.input_parameters.get('step', [])

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -776,45 +776,9 @@ class GromacsParser(MDParser):
             if self.mdp_std_filename in filename:
                 return os.path.join(self._maindir, f)
 
-        return next(iter(self.get_all_gromacs_files(self.mdp_ext)), None)
+        return next(iter(self.get_gromacs_files(self.mdp_ext)), None)
 
-    def get_gromacs_file(self, ext):
-        files = [d for d in self._gromacs_files if d.endswith(ext)]
-
-        if len(files) == 0:
-            return ''
-
-        if len(files) == 1:
-            return os.path.join(self._maindir, files[0])
-
-        # we assume that the file has the same basename as the log file e.g.
-        # out.log would correspond to out.tpr and out.trr and out.edr
-        for f in files:
-            if f.rsplit('.', 1)[0] == self._basename:
-                return os.path.join(self._maindir, f)
-
-        for f in files:
-            if f.rsplit('.', 1)[0].startswith(self._basename):
-                return os.path.join(self._maindir, f)
-
-        # if the files are all named differently, we guess that the one that does not
-        # share the same basename would be file we are interested in
-        # e.g. in a list of files out.log someout.log out.tpr out.trr another.tpr file.trr
-        # we guess that the out.* files belong together and the rest that does not share
-        # a basename would be grouped together
-        counts = []
-        for f in files:
-            count = 0
-            for reff in self._gromacs_files:
-                if f.rsplit('.', 1)[0] == reff.rsplit('.', 1)[0]:
-                    count += 1
-            if count == 1:
-                return os.path.join(self._maindir, f)
-            counts.append(count)
-
-        return os.path.join(self._maindir, files[counts.index(min(counts))])
-
-    def get_all_gromacs_files(
+    def get_gromacs_files(
         self, ext, return_all=False
     ) -> Union[Tuple[List[str], List[str], List[str]], List[str]]:
         """
@@ -887,7 +851,7 @@ class GromacsParser(MDParser):
 
         # TODO read also from ene
         # Make sure *.edr file is part of upload before attempting to parse it.
-        edr_file = next(iter(self.get_all_gromacs_files('edr')), None)
+        edr_file = next(iter(self.get_gromacs_files('edr')), None)
         if edr_file:
             self.energy_parser.keys()
             self.energy_parser.mainfile = edr_file
@@ -1169,7 +1133,7 @@ class GromacsParser(MDParser):
         try:
             n_atoms = self.traj_parser.get('n_atoms', 0)
         except Exception:
-            gro_file = next(iter(self.get_all_gromacs_files('gro')), None)
+            gro_file = next(iter(self.get_gromacs_files('gro')), None)
             self.traj_parser.mainfile = gro_file
             n_atoms = self.traj_parser.get('n_atoms', 0)
         atoms_info = self.traj_parser.get('atoms_info', {})
@@ -1578,9 +1542,7 @@ class GromacsParser(MDParser):
             params_key = 'free_energy_calculation_parameters'
             method[params_key] = self.get_free_energy_calculation_parameters()
 
-            self.xvg_parser.mainfile = next(
-                iter(self.get_all_gromacs_files('xvg')), None
-            )
+            self.xvg_parser.mainfile = next(iter(self.get_gromacs_files('xvg')), None)
             free_energies = self.xvg_parser.get('results')
 
             title = free_energies.get('title', '') if free_energies is not None else ''
@@ -1739,7 +1701,7 @@ class GromacsParser(MDParser):
             contains_files: List[str] = []
             fallback_files: List[str] = []
             for file_ext in traj_priority_group:
-                traj_files_tup = self.get_all_gromacs_files(file_ext, return_all=True)
+                traj_files_tup = self.get_gromacs_files(file_ext, return_all=True)
                 if traj_files_tup:
                     for file_path in traj_files_tup[0]:
                         if matches_mainfile(file_path):
@@ -1784,7 +1746,7 @@ class GromacsParser(MDParser):
         self._frame_rate = None
 
         header = self.log_parser.get('header', {})
-        topology_file = next(iter(self.get_all_gromacs_files('tpr')), None)
+        topology_file = next(iter(self.get_gromacs_files('tpr')), None)
         sec_run = Run()
         sec_run.program = Program(
             name='GROMACS',

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 import os
+import sys
 import numpy as np
 import logging
 import re
@@ -774,8 +775,37 @@ class GromacsParser(MDParser):
 
         return self.get_gromacs_file(self.mdp_ext)
 
-    def get_gromacs_file(self, ext):
+    def get_gromacs_file(self, ext, return_all=False):
         files = [d for d in self._gromacs_files if d.endswith(ext)]
+
+        if return_all:
+            all_files = {}
+            no_basename_match, counts = [], []
+            for f in files:
+                # we assume that the file has the same basename as the log file e.g.
+                # out.log would correspond to out.tpr and out.trr and out.edr
+                if f.rsplit('.', 1)[0] == self._basename:
+                    all_files[0] = os.path.join(self._maindir, f)
+                elif f.rsplit('.', 1)[0].startswith(self._basename):
+                    all_files[1] = os.path.join(self._maindir, f)
+                else:
+                    # if the files are all named differently, we guess that the one that does not
+                    # share the same basename would be file we are more likely interested in and sort
+                    # the results accordingly
+                    count = 0
+                    for reff in self._gromacs_files:
+                        if f.rsplit('.', 1)[0] == reff.rsplit('.', 1)[0]:
+                            count += 1
+                    counts.append(count)
+                    no_basename_match.append(os.path.join(self._maindir, f))
+            if no_basename_match:
+                for idx, val in enumerate(
+                    [x for _, x in sorted(zip(counts, no_basename_match))]
+                ):
+                    all_files[idx + 2] = val
+            sorted(all_files.items())
+
+            return all_files
 
         if len(files) == 0:
             return ''
@@ -805,7 +835,10 @@ class GromacsParser(MDParser):
                 if f.rsplit('.', 1)[0] == reff.rsplit('.', 1)[0]:
                     count += 1
             if count == 1:
-                return os.path.join(self._maindir, f)
+                if return_all:
+                    all_files.extend(os.path.join(self._maindir, f))
+                else:
+                    return os.path.join(self._maindir, f)
             counts.append(count)
 
         return os.path.join(self._maindir, files[counts.index(min(counts))])
@@ -1639,26 +1672,52 @@ class GromacsParser(MDParser):
         """
         Find and set trajectory files following the priority:
         "trr" > "xtc", fall back "pdb" > "gro".
+        Prioritize files with exact basename match over files with partial basename match over other files.
         """
+        traj_priority_list = ['trr', 'xtc', 'pdb', 'gro']
 
-        def _get_traj_file(ext):
-            primary_file = self.get_gromacs_file(ext)
-            if primary_file is None:
-                return None
-            primary_file_nopath = primary_file.rsplit('.', 1)[0]
-            primary_file_nopath = primary_file_nopath.rsplit('/')[-1]
+        def is_readable(file_path):
+            positions = None
+            test_universe = MDAnalysis.Universe(self.traj_parser.mainfile, file_path)
+            if test_universe is not None:
+                atoms = getattr(test_universe, 'atoms', None)
+                positions = getattr(atoms, 'positions', None)
 
-            return primary_file
-
-        # Iterate over copy of list to avoid skipping elements
-        for ext in self.traj_file_priority_list[:]:
-            traj_file = _get_traj_file(ext)
-            if traj_file:
-                return [traj_file]
+            if positions is not None:
+                # A readable, the correct trajectory has been found
+                return True
             else:
-                # Remove the missing file format from priority list
-                self.traj_file_priority_list.remove(ext)
-        # If no matching trajectory file is found, return an empty list
+                # If positions are None, log a warning
+                self.logger.warning(
+                    'No positions in trajectory file: {}'.format(
+                        self.traj_parser.auxilliary_files[0].rsplit('/')[1]
+                    )
+                )
+                return False
+
+        def sort_by_priority(files_dicts):
+            seen_keys = []
+            for d in files_dicts:
+                for key in d:
+                    if key not in seen_keys:
+                        seen_keys.append(key)
+            sorted_values = [
+                d.get(key, None) for key in sorted(seen_keys) for d in files_dicts
+            ]
+            sorted_values = list(filter(lambda x: x is not None, sorted_values))
+
+            return sorted_values
+
+        # sort all entries in self.gromacs_files by priority_list and filename match
+        files = []
+        for p in traj_priority_list:
+            results = self.get_gromacs_file(p, return_all=True)
+            files.append(results)
+        if files:
+            files = sort_by_priority(files)
+            for file_path in files:
+                if is_readable(file_path):
+                    return [file_path]
         return []
 
     def write_to_archive(self):
@@ -1723,61 +1782,8 @@ class GromacsParser(MDParser):
                 )
 
         self.traj_parser.mainfile = topology_file
-        # JFR comment: I have no idea if output trajectory file can be specified in input
-        # ? Do you mean, e.g., a flag in the *.log file that specifies the output trajectory format?
-        self.traj_file_priority_list = ['trr', 'xtc', 'pdb', 'gro']
         self.traj_parser.auxilliary_files = self.find_trajectory_files()
-        if self.traj_parser.auxilliary_files:
-            # Iterate through available trajectory formats until a valid one is found
-            while self.traj_file_priority_list:
-                # Check if the selected trajectory file can be read properly
-                positions = None
-                if (universe := self.traj_parser.universe) is not None:
-                    atoms = getattr(universe, 'atoms', None)
-                    positions = getattr(atoms, 'positions', None)
-
-                if positions is not None:
-                    # A readable, complete trajectory has been found, break the loop
-                    break
-
-                # If positions are None, log a warning
-                self.logger.warning(
-                    'No positions in trajectory file: {}'.format(
-                        self.traj_parser.auxilliary_files[0].split('/')[-1]
-                    )
-                )
-
-                # Check if other files with the same extension are available, attempt to generate universe from them
-                failed_ext = self.traj_parser.auxilliary_files[0].split('.')[-1]
-                failed_file = self.traj_parser.auxilliary_files[0].split('/')[-1]
-                _files = [f for f in self._gromacs_files if f.endswith(failed_ext)]
-                _files.remove(failed_file)
-                if _files:
-                    self._gromacs_files.remove(failed_file)
-                    # Try the next trajectory file with the same extension
-                    self.traj_parser.auxilliary_files = self.find_trajectory_files()
-                else:
-                    # Remove the failed file format from priority list
-                    self.traj_file_priority_list.remove(
-                        self.traj_parser.auxilliary_files[0].split('.')[-1]
-                    )
-                    if self.traj_file_priority_list:
-                        # Try the next trajectory file format in the priority list
-                        self.traj_parser.auxilliary_files = self.find_trajectory_files()
-                    else:
-                        # If no options are left, log a warning and exit loop
-                        self.logger.error('No valid trajectory files found.')
-                        # ! If parsing is not stopped here, it fails in parse_system() due to MDAnalysis universe not being created
-                        raise FileNotFoundError(
-                            'No recognized trajectory file is part of the upload.'
-                        )
-
-        else:
-            self.logger.error('No recognized trajectory file is part of the upload.')
-            # ! If parsing is not stopped here, it fails in parse_system() due to MDAnalysis universe not being created
-            raise FileNotFoundError(
-                'No recognized trajectory file is part of the upload.'
-            )
+        sys.exit()
 
         self.parse_method()
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -21,6 +21,7 @@ import numpy as np
 import logging
 import re
 import datetime
+from itertools import chain
 from typing import List, Dict, Tuple, Union
 
 import panedr
@@ -1702,7 +1703,7 @@ class GromacsParser(MDParser):
         exact_matches: List[str] = []
         contains_files: List[str] = []
         fallback_files: List[str] = []
-        for file_ext in traj_priority_list:
+        for file_ext in chain(traj_priority_list[:2], traj_priority_list[2:]):
             traj_files_tup = self.get_gromacs_files(file_ext, return_all=True)
             if traj_files_tup:
                 exact_matches.extend(traj_files_tup[0])
@@ -1718,7 +1719,7 @@ class GromacsParser(MDParser):
                 return file_path
 
         # If no matching trajectory file is found, self.trajectory_parser.auxilliary_files remains default (None,).
-        # Mismatched trajectory files are logged as a warning.
+        # Mismatched trajectory files are appended as 'extra' information to the logged warning.
         self.logger.warning(
             'Provided trajectory files do not match topology.',
             # TODO: decide wether knowing the mismatched trajectory files is useful for the user.

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -832,7 +832,7 @@ class GromacsParser(MDParser):
         if len(files) == 0:
             return []
 
-        all_files = ([], [])
+        all_files: Tuple[List, List] = ([], [])
         contain_basename, match_priority, no_basename_match, counts = [], [], [], []
         for f in files:
             filename = f.rsplit('.', 1)[0]
@@ -1729,18 +1729,18 @@ class GromacsParser(MDParser):
         # Get all MDAnalysis-compatible trajectory files in self.gromacs_files,
         # sorted by extension priority (priority_list) and filename.
         # Select matching trajectory with highest priority.
-        fallback_files = []
+        fallback_files: List[str] = []
         for file_ext in traj_priority_list:
             traj_files_tup = self.get_all_gromacs_files(file_ext, return_all=True)
             if traj_files_tup:
                 for file_path in traj_files_tup[0]:
                     if matches_mainfile(file_path):
-                        return
+                        return None
                 fallback_files.extend(traj_files_tup[1])
         # Search `fallback_files` only if no higher-priority match was found
         for file_path in fallback_files:
             if matches_mainfile(file_path):
-                return
+                return None
         # If no matching trajectory file is found, self.trajectory_parser.auxilliary_files remains default (None,).
         # Mismatched trajectory files are logged as a warning.
         self.logger.warning(
@@ -1748,7 +1748,7 @@ class GromacsParser(MDParser):
             # TODO: decide wether returning the offending file is useful.
             extra={'file_paths': failed_files},
         )
-        return
+        return None
 
     def write_to_archive(self):
         self._maindir = os.path.dirname(self.mainfile)

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1739,12 +1739,9 @@ class GromacsParser(MDParser):
             results = self.get_gromacs_file(p, return_all=True)
             # if files with the correct extension are found, add to the list
             if results:
-                print(p, len(results.keys()))
                 traj_files_list.append(results)
         if traj_files_list:
-            print(traj_files_list)
             traj_files_list = sort_by_priority(traj_files_list)
-            print(traj_files_list)
             for file_path in traj_files_list:
                 if is_readable(file_path):
                     return [file_path]

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1660,7 +1660,7 @@ class GromacsParser(MDParser):
             else:
                 # Remove the missing file format from priority list
                 self.traj_file_priority_list.remove(ext)
-
+        # If no matching trajectory file is found, return an empty list
         return []
 
     def write_to_archive(self):
@@ -1760,7 +1760,10 @@ class GromacsParser(MDParser):
                 else:
                     # If no options are left, log a warning and exit loop
                     self.logger.error('No valid trajectory files found.')
-                    break
+                    # ! If parsing is not stopped here, it fails in parse_system() due to MDAnalysis universe not being created
+                    raise FileNotFoundError(
+                        'No recognized trajectory file is part of the upload.'
+                    )
 
         else:
             self.logger.error('No recognized trajectory file is part of the upload.')

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1688,11 +1688,9 @@ class GromacsParser(MDParser):
         trajectory_file = os.path.basename(self.traj_parser.auxilliary_files[0])
         sec_input_output_files.x_gromacs_inout_file_trajtrr = trajectory_file
 
-        try:
+        if self.energy_parser.mainfile is not None:
             edr_file = os.path.basename(self.energy_parser.mainfile)
             sec_input_output_files.x_gromacs_inout_file_eneredr = edr_file
-        except TypeError:
-            logging.warning('Error parsing `edr` file, no energy data available.')
 
         sec_control_parameters = x_gromacs_section_control_parameters()
         sec_run.x_gromacs_section_control_parameters = sec_control_parameters

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -777,37 +777,47 @@ class GromacsParser(MDParser):
     def get_gromacs_file(self, ext, return_all=False):
         files = [d for d in self._gromacs_files if d.endswith(ext)]
 
+        if len(files) == 0:
+            return ''
+
         if return_all:
             all_files = {}
-            no_basename_match, counts = [], []
+            contain_basename, no_basename_match, counts = [], [], []
             for f in files:
-                # we assume that the file has the same basename as the log file e.g.
-                # out.log would correspond to out.tpr and out.trr and out.edr
+                # We assume that the matching trajectory file has (or starts with)
+                # the same basename as the log file, e.g., out.log would correspond to
+                # out.tpr and out.trr and out.edr (or out_some.tpr ...).
+                # These files are therefore given first (second... ) priority in the dictionary.
                 if f.rsplit('.', 1)[0] == self._basename:
-                    all_files[0] = os.path.join(self._maindir, f)
+                    all_files[0] = {0: os.path.join(self._maindir, f)}
                 elif f.rsplit('.', 1)[0].startswith(self._basename):
-                    all_files[1] = os.path.join(self._maindir, f)
+                    contain_basename.append(os.path.join(self._maindir, f))
                 else:
-                    # if the files are all named differently, we guess that the one that does not
-                    # share the same basename would be file we are more likely interested in and sort
-                    # the results accordingly
+                    # if potential files are named differently, we guess that the ones with a unique name
+                    # would be the files we are more likely interested in, and sort the results accordingly
                     count = 0
                     for reff in self._gromacs_files:
                         if f.rsplit('.', 1)[0] == reff.rsplit('.', 1)[0]:
                             count += 1
                     counts.append(count)
                     no_basename_match.append(os.path.join(self._maindir, f))
+            # add the files starting with the same basename in the order they were encountered
+            if contain_basename:
+                all_files[1] = {
+                    idx: file_path for idx, file_path in enumerate(contain_basename)
+                }
+            # sort files with the correct format, but different basename:
+            # according to the number of other files with the same name
+            # (fewer files with same name: higher priority)
             if no_basename_match:
-                for idx, val in enumerate(
-                    [x for _, x in sorted(zip(counts, no_basename_match))]
-                ):
-                    all_files[idx + 2] = val
-            sorted(all_files.items())
+                all_files[2] = {
+                    idx: file_path
+                    for idx, file_path in enumerate(
+                        [x for _, x in sorted(zip(counts, no_basename_match))]
+                    )
+                }
 
             return all_files
-
-        if len(files) == 0:
-            return ''
 
         if len(files) == 1:
             return os.path.join(self._maindir, files[0])
@@ -850,6 +860,7 @@ class GromacsParser(MDParser):
         # TODO read also from ene
         # Make sure *.edr file is part of upload before attempting to parse it.
         edr_file = self.get_gromacs_file('edr')
+        thermo_data = None
         if edr_file:
             # If the edr file can't be read or there are no keys, an error will be raised by the energy parser
             self.energy_parser.mainfile = edr_file
@@ -857,7 +868,11 @@ class GromacsParser(MDParser):
                 self.energy_parser.keys()
                 thermo_data = self.energy_parser
             except Exception:
-                thermo_data = None
+                self.logger.error('Error reading edr file.')
+            # self.energy_parser.mainfile = edr_file
+            # self.energy_parser.keys()
+            # thermo_data = self.energy_parser
+
         if not thermo_data:
             # try to get it from log file
             steps = self.input_parameters.get('step', [])
@@ -1656,7 +1671,7 @@ class GromacsParser(MDParser):
             edr_file = os.path.basename(self.energy_parser.mainfile)
             sec_input_output_files.x_gromacs_inout_file_eneredr = edr_file
         except TypeError:
-            logging.warning('Error parsing *.edr file, no energy data available.')
+            logging.warning('Error parsing `edr` file, no energy data available.')
 
         sec_control_parameters = x_gromacs_section_control_parameters()
         sec_run.x_gromacs_section_control_parameters = sec_control_parameters
@@ -1677,44 +1692,60 @@ class GromacsParser(MDParser):
 
         def is_readable(file_path):
             positions = None
-            test_universe = MDAnalysis.Universe(self.traj_parser.mainfile, file_path)
-            if test_universe is not None:
+            try:
+                test_universe = MDAnalysis.Universe(
+                    self.traj_parser.mainfile, file_path
+                )
                 atoms = getattr(test_universe, 'atoms', None)
                 positions = getattr(atoms, 'positions', None)
-
-            if positions is not None:
-                # A readable, the correct trajectory has been found
-                return True
-            else:
-                # If positions are None, log a warning
+            except Exception:
                 self.logger.warning(
-                    'No positions in trajectory file: {}'.format(
-                        self.traj_parser.auxilliary_files[0].rsplit('/')[1]
-                    )
+                    'Error reading positions from trajectory file: {}'.format(file_path)
                 )
-                return False
+            if positions is not None:
+                # If readable, the correct trajectory has been found
+                return True
+
+            return False
 
         def sort_by_priority(files_dicts):
+            # accounting for multiple files starting with the basename (priority 1)
+            # we expect each dict to contain the exact basename match (priority 0)
+            n_keys = max([len(d[1]) if d.get(1) else 0 for d in files_dicts]) + 1
             seen_keys = []
+            dicts_list = []
             for d in files_dicts:
                 for key in d:
-                    if key not in seen_keys:
-                        seen_keys.append(key)
+                    if key == 1:
+                        d[key] = {idx + 1: val for idx, val in d[key].items()}
+                    if key == 2:
+                        d[key] = {idx + n_keys: val for idx, val in d[key].items()}
+                    dicts_list.append(d.get(key, None))
+                    for idx in d[key].keys():
+                        if idx not in seen_keys:
+                            seen_keys.append(idx)
+            # make sure the returned list is sorted by our priority order
             sorted_values = [
-                d.get(key, None) for key in sorted(seen_keys) for d in files_dicts
+                d.get(key, None) for key in sorted(seen_keys) for d in dicts_list
             ]
+            # remove None values from not present files
             sorted_values = list(filter(lambda x: x is not None, sorted_values))
 
             return sorted_values
 
         # sort all entries in self.gromacs_files by priority_list and filename match
-        files = []
+        traj_files_list = []
         for p in traj_priority_list:
             results = self.get_gromacs_file(p, return_all=True)
-            files.append(results)
-        if files:
-            files = sort_by_priority(files)
-            for file_path in files:
+            # if files with the correct extension are found, add to the list
+            if results:
+                print(p, len(results.keys()))
+                traj_files_list.append(results)
+        if traj_files_list:
+            print(traj_files_list)
+            traj_files_list = sort_by_priority(traj_files_list)
+            print(traj_files_list)
+            for file_path in traj_files_list:
                 if is_readable(file_path):
                     return [file_path]
         return []

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -370,7 +370,7 @@ class GromacsEDRParser(FileParser):
     @property
     def length(self):
         if self.fileedr is None:
-            return None
+            return 0
         return self.fileedr.shape[0]
 
 
@@ -787,7 +787,7 @@ class GromacsParser(MDParser):
         by basename similarity and uniqueness. If False, return the first file
         that matches the basename of the main file.
         Returns:
-        - tuple: return_all == True. A tuple of two lists.
+        - tuple: return_all == True. A tuple of three lists.
           The first list contains the files with at least partially the same
           basename as the main file, sorted by descending match priority.
           The second list contains the files with different basenames,
@@ -853,7 +853,6 @@ class GromacsParser(MDParser):
         # Make sure *.edr file is part of upload before attempting to parse it.
         edr_file = next(iter(self.get_gromacs_files('edr')), None)
         if edr_file:
-            self.energy_parser.keys()
             self.energy_parser.mainfile = edr_file
             thermo_data = self.energy_parser
         if not thermo_data:
@@ -1663,7 +1662,7 @@ class GromacsParser(MDParser):
         )
         sec_control_parameters.m_set(quantity_def, input_parameters)
 
-    def find_trajectory_file(self) -> Union[str, None]:
+    def find_trajectory_file(self) -> str:
         """
         Find and set trajectory files following the priority:
         "trr" > "xtc", fallback "pdb" > "gro". Prioritize files with exact basename
@@ -1685,46 +1684,52 @@ class GromacsParser(MDParser):
             # set the trajectory file to the current file_path,
             # the traj_parser attempts to create a MDAnalysis universe
             try:
-                self.traj_parser.auxilliary_files = [file_path]
+                print(
+                    f'In matches_mainfile: {self.traj_parser.mainfile}, {file_path}\n'
+                )
+                u = MDAnalysis.Universe(self.traj_parser.mainfile, file_path)
+                if u.atoms:
+                    return True
             except Exception as e:
                 # If the trajectory file does not match the topology,
                 # the trajectory file remains None
                 failed_files.append(file_path)
                 return False
-            else:
-                return True
 
         # Get all MDAnalysis-compatible trajectory files in self.gromacs_files,
         # sorted by extension priority (priority_list) and filename.
         # Select matching trajectory with highest priority.
-        def try_priority_group(traj_priority_group) -> bool:
+        def try_priority_group(traj_priority_group) -> str:
             contains_files: List[str] = []
             fallback_files: List[str] = []
             for file_ext in traj_priority_group:
+                print(f'\nChecking for {file_ext} files...\n')
                 traj_files_tup = self.get_gromacs_files(file_ext, return_all=True)
                 if traj_files_tup:
                     for file_path in traj_files_tup[0]:
                         if matches_mainfile(file_path):
-                            return True
+                            return file_path
                     contains_files.extend(traj_files_tup[1])
                     fallback_files.extend(traj_files_tup[2])
             # If no exact filename match was found, check for files containing the mainfile name
             for file_path in contains_files:
                 if matches_mainfile(file_path):
-                    return True
+                    return file_path
             # Search `fallback_files` only if no higher-priority match was found
             for file_path in fallback_files:
                 if matches_mainfile(file_path):
-                    return True
+                    return file_path
             # No match found in this priority group
-            return False
+            return ''
 
         # Check 'trr' and 'xtc' first
-        if try_priority_group(traj_priority_list[:2]):
-            return None
+        traj_file = try_priority_group(traj_priority_list[:2])
+        if traj_file:
+            return traj_file
         # Then check 'pdb' and 'gro'
-        if try_priority_group(traj_priority_list[2:]):
-            return None
+        traj_file = try_priority_group(traj_priority_list[2:])
+        if traj_file:
+            return traj_file
 
         # If no matching trajectory file is found, self.trajectory_parser.auxilliary_files remains default (None,).
         # Mismatched trajectory files are logged as a warning.
@@ -1733,7 +1738,7 @@ class GromacsParser(MDParser):
             # TODO: decide wether knowing the mismatched trajectory files is useful for the user.
             extra={'file_paths': failed_files},
         )
-        return None
+        return ''
 
     def write_to_archive(self):
         self._maindir = os.path.dirname(self.mainfile)
@@ -1746,6 +1751,7 @@ class GromacsParser(MDParser):
         self._frame_rate = None
 
         header = self.log_parser.get('header', {})
+        # ? Should we allow 'gro' as fallback for topology?
         topology_file = next(iter(self.get_gromacs_files('tpr')), None)
         sec_run = Run()
         sec_run.program = Program(
@@ -1795,8 +1801,8 @@ class GromacsParser(MDParser):
                 )
 
         self.traj_parser.mainfile = topology_file
-        # Trajectory file is passed to MDAnalysisParser parser under the hood
-        self.find_trajectory_file()
+
+        self.traj_parser.auxilliary_files = self.find_trajectory_file()
 
         self.parse_method()
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -816,6 +816,7 @@ class GromacsParser(MDParser):
         n_frames = self.traj_parser.get('n_frames')
 
         # TODO read also from ene
+        # Make sure *.edr file is part of upload before attempting to parse it.
         edr_file = self.get_gromacs_file('edr')
         if edr_file:
             self.energy_parser.mainfile = edr_file
@@ -840,7 +841,10 @@ class GromacsParser(MDParser):
 
         if not thermo_data:
             # get it from edr file
-            thermo_data = self.energy_parser
+            try:
+                thermo_data = self.energy_parser
+            except Exception as e:
+                self.logger.warning(f'Error parsing edr file: {e}')
 
         calculation_times = thermo_data.get('Time', [])
         time_step = self.input_parameters.get('dt')
@@ -1619,10 +1623,9 @@ class GromacsParser(MDParser):
 
         try:
             edr_file = os.path.basename(self.energy_parser.mainfile)
+            sec_input_output_files.x_gromacs_inout_file_eneredr = edr_file
         except TypeError:
-            edr_file = None
-
-        sec_input_output_files.x_gromacs_inout_file_eneredr = edr_file
+            logging.warning(f'Error parsing *.edr file, no energy data available.')
 
         sec_control_parameters = x_gromacs_section_control_parameters()
         sec_run.x_gromacs_section_control_parameters = sec_control_parameters
@@ -1667,13 +1670,11 @@ class GromacsParser(MDParser):
 
             if trajectory_file:
                 return [trajectory_file]
-
             else:
                 # Try pdb first, fallback to gro
                 trajectory_file = _get_file_or_fallback('pdb', 'gro')
                 if trajectory_file:
                     return [trajectory_file]
-
         except FileNotFoundError:
             logging.warning(f'No coordinates found, no visualization possible.')
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -816,27 +816,27 @@ class GromacsParser(MDParser):
 
     def get_all_gromacs_files(
         self, ext, return_all=False
-    ) -> Union[Tuple[List[str], List[str]], List[str]]:
+    ) -> Union[Tuple[List[str], List[str], List[str]], List[str]]:
         """
         Tries to find all the Gromacs output files with the given extension.
         return_all: If True, return all files with the given extension, sorted
         by basename similarity and uniqueness. If False, return the first file
         that matches the basename of the main file.
         Returns:
-        - tuple: A tuple of two lists. The first list contains the files with
-          at least partially the same basename as the main file, sorted by
-          descending match priority.
-          The second list contains the files with different basenames, sorted
-          by uniqueness. (return_all == True)
-        - [str]: A list of files with the best match to the basename of the main
-          file found, sorted by descending match priority. (return_all == False)
+        - tuple: return_all == True. A tuple of two lists.
+          The first list contains the files with at least partially the same
+          basename as the main file, sorted by descending match priority.
+          The second list contains the files with different basenames,
+          sorted by descending uniqueness.
+        - [str]: return_all == False. A list of files with the best match to the
+          basename of the main file found, sorted by descending match priority.
         - []: An empty list if no file with the given extension is found.
         """
         files = [d for d in self._gromacs_files if d.endswith(ext)]
         if len(files) == 0:
             return []
 
-        all_files: Tuple[List, List] = ([], [])
+        all_files: Tuple[List, List, List] = ([], [], [])
         contain_basename, match_priority, no_basename_match, counts = [], [], [], []
         for f in files:
             filename = f.rsplit('.', 1)[0]
@@ -867,16 +867,16 @@ class GromacsParser(MDParser):
                 no_basename_match.append(os.path.join(self._maindir, f))
         # add the files containing the same basename sorted by priority
         if contain_basename:
-            all_files[0].extend(
+            all_files[1].extend(
                 [x for _, x in sorted(zip(match_priority, contain_basename))]
             )
             if not return_all:
-                return all_files[0]
+                return all_files[1]
         # add the files with different basenames sorted by uniqueness
         if no_basename_match:
-            all_files[1].extend([x for _, x in sorted(zip(counts, no_basename_match))])
+            all_files[2].extend([x for _, x in sorted(zip(counts, no_basename_match))])
             if not return_all:
-                return all_files[1]
+                return all_files[2]
 
         return all_files
 
@@ -1715,16 +1715,20 @@ class GromacsParser(MDParser):
                                > ... > out.pdb > ... > out.gro > ...
         """
         traj_priority_list = ['trr', 'xtc', 'pdb', 'gro']
-
-        # Check if an MDAnalysis universe can be created from the mainfile and the current trajectory file
         failed_files = []
 
-        def matches_mainfile(file_path):
-            # set the trajectory file to the current file_path, the traj_parser attempts to create a universe
+        def matches_mainfile(file_path) -> bool:
+            """
+            Check if an MDAnalysis universe can be created from the mainfile (topology)
+            and the current trajectory file.
+            """
+            # set the trajectory file to the current file_path,
+            # the traj_parser attempts to create a MDAnalysis universe
             try:
                 self.traj_parser.auxilliary_files = [file_path]
             except Exception as e:
-                # If the trajectory file does not match the topology, the trajectory file remains None
+                # If the trajectory file does not match the topology,
+                # the trajectory file remains None
                 failed_files.append(file_path)
                 return False
             else:
@@ -1734,13 +1738,33 @@ class GromacsParser(MDParser):
         # sorted by extension priority (priority_list) and filename.
         # Select matching trajectory with highest priority.
         fallback_files: List[str] = []
-        for file_ext in traj_priority_list:
-            traj_files_tup = self.get_all_gromacs_files(file_ext, return_all=True)
-            if traj_files_tup:
-                for file_path in traj_files_tup[0]:
-                    if matches_mainfile(file_path):
-                        return None
-                fallback_files.extend(traj_files_tup[1])
+
+        def try_priority_group(traj_priority_group) -> bool:
+            contains_files: List[str] = []
+            for file_ext in traj_priority_group:
+                print(file_ext)
+                traj_files_tup = self.get_all_gromacs_files(file_ext, return_all=True)
+                print(traj_files_tup)
+                if traj_files_tup:
+                    for file_path in traj_files_tup[0]:
+                        if matches_mainfile(file_path):
+                            return True
+                    contains_files.extend(traj_files_tup[1])
+                    fallback_files.extend(traj_files_tup[2])
+            # If no exact filename match was found, check for files containing the mainfile name
+            for file_path in contains_files:
+                if matches_mainfile(file_path):
+                    return True
+            # No match found in this priority group
+            return False
+
+        # Check 'trr' and 'xtc' first
+        if try_priority_group(traj_priority_list[:2]):
+            return None
+        # Then check 'pdb' and 'gro'
+        if try_priority_group(traj_priority_list[2:]):
+            return None
+
         # Search `fallback_files` only if no higher-priority match was found
         for file_path in fallback_files:
             if matches_mainfile(file_path):
@@ -1749,7 +1773,7 @@ class GromacsParser(MDParser):
         # Mismatched trajectory files are logged as a warning.
         self.logger.warning(
             'Trajectory files do not match topology.',
-            # TODO: decide wether returning the offending file is useful.
+            # TODO: decide wether knowing the mismatched trajectory files is useful for the user.
             extra={'file_paths': failed_files},
         )
         return None

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -776,7 +776,7 @@ class GromacsParser(MDParser):
             if self.mdp_std_filename in filename:
                 return os.path.join(self._maindir, f)
 
-        return self.get_all_gromacs_files(self.mdp_ext)
+        return next(iter(self.get_all_gromacs_files(self.mdp_ext)), None)
 
     def get_gromacs_file(self, ext):
         files = [d for d in self._gromacs_files if d.endswith(ext)]
@@ -816,7 +816,7 @@ class GromacsParser(MDParser):
 
     def get_all_gromacs_files(
         self, ext, return_all=False
-    ) -> Union[Tuple[List[str], List[str]], str, None]:
+    ) -> Union[Tuple[List[str], List[str]], List[str]]:
         """
         Tries to find all the Gromacs output files with the given extension.
         return_all: if True, return all files with the given extension, sorted by basename similarity
@@ -830,7 +830,7 @@ class GromacsParser(MDParser):
         """
         files = [d for d in self._gromacs_files if d.endswith(ext)]
         if len(files) == 0:
-            return
+            return []
 
         all_files = ([], [])
         contain_basename, match_priority, no_basename_match, counts = [], [], [], []
@@ -839,9 +839,9 @@ class GromacsParser(MDParser):
             # Sort all files with extension `ext` into three priority categories:
             # 1. files with exact basename match to the main file
             if filename == self._basename:
-                if not return_all:
-                    return os.path.join(self._maindir, f)
                 all_files[0].append(os.path.join(self._maindir, f))
+                if not return_all:
+                    return all_files[0]
             # 2. files containing the basename of the main file, order: startswith  > endswith > in
             elif self._basename in filename:
                 priority = (
@@ -863,18 +863,16 @@ class GromacsParser(MDParser):
                 no_basename_match.append(os.path.join(self._maindir, f))
         # add the files containing the same basename sorted by priority
         if contain_basename:
-            contain_basename = [
-                x for _, x in sorted(zip(match_priority, contain_basename))
-            ]
+            all_files[0].extend(
+                [x for _, x in sorted(zip(match_priority, contain_basename))]
+            )
             if not return_all:
-                return contain_basename[0]
-            all_files[0].extend(contain_basename)
+                return all_files[0]
         # add the files with different basenames sorted by uniqueness
         if no_basename_match:
-            no_basename_match = [x for _, x in sorted(zip(counts, no_basename_match))]
+            all_files[1].extend([x for _, x in sorted(zip(counts, no_basename_match))])
             if not return_all:
-                return no_basename_match[0]
-            all_files[1].extend(no_basename_match)
+                return all_files[1]
 
         return all_files
 
@@ -885,7 +883,7 @@ class GromacsParser(MDParser):
 
         # TODO read also from ene
         # Make sure *.edr file is part of upload before attempting to parse it.
-        edr_file = self.get_all_gromacs_files('edr')
+        edr_file = next(iter(self.get_all_gromacs_files('edr')), None)
         if edr_file:
             self.energy_parser.keys()
             self.energy_parser.mainfile = edr_file
@@ -1167,7 +1165,7 @@ class GromacsParser(MDParser):
         try:
             n_atoms = self.traj_parser.get('n_atoms', 0)
         except Exception:
-            gro_file = self.get_all_gromacs_files('gro')
+            gro_file = next(iter(self.get_all_gromacs_files('gro')), None)
             self.traj_parser.mainfile = gro_file
             n_atoms = self.traj_parser.get('n_atoms', 0)
         atoms_info = self.traj_parser.get('atoms_info', {})
@@ -1576,7 +1574,9 @@ class GromacsParser(MDParser):
             params_key = 'free_energy_calculation_parameters'
             method[params_key] = self.get_free_energy_calculation_parameters()
 
-            self.xvg_parser.mainfile = self.get_all_gromacs_files('xvg')
+            self.xvg_parser.mainfile = next(
+                iter(self.get_all_gromacs_files('xvg')), None
+            )
             free_energies = self.xvg_parser.get('results')
 
             title = free_energies.get('title', '') if free_energies is not None else ''
@@ -1699,7 +1699,7 @@ class GromacsParser(MDParser):
         )
         sec_control_parameters.m_set(quantity_def, input_parameters)
 
-    def find_trajectory_file(self):
+    def find_trajectory_file(self) -> Union[str, None]:
         """
         Find and set trajectory files following the priority:
         "trr" > "xtc", fallback "pdb" > "gro". Prioritize files with exact basename
@@ -1761,7 +1761,7 @@ class GromacsParser(MDParser):
         self._frame_rate = None
 
         header = self.log_parser.get('header', {})
-        topology_file = self.get_all_gromacs_files('tpr')
+        topology_file = next(iter(self.get_all_gromacs_files('tpr')), None)
         sec_run = Run()
         sec_run.program = Program(
             name='GROMACS',

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -819,14 +819,18 @@ class GromacsParser(MDParser):
     ) -> Union[Tuple[List[str], List[str]], List[str]]:
         """
         Tries to find all the Gromacs output files with the given extension.
-        return_all: if True, return all files with the given extension, sorted by basename similarity
-        and uniqueness. If False, return the first file that matches the basename of the main file.
+        return_all: If True, return all files with the given extension, sorted
+        by basename similarity and uniqueness. If False, return the first file
+        that matches the basename of the main file.
         Returns:
-            - tuple: A tuple of two lists, the first list contains the files with at least partially
-            the same basename as the main file, the second list contains the files with different
-            basenames, sorted by uniqueness. (return_all == True)
-            - str: the first file that matches the basename of the main file. (return_all == False)
-            - None: if no file with the given extension is found.
+        - tuple: A tuple of two lists. The first list contains the files with
+          at least partially the same basename as the main file, sorted by
+          descending match priority.
+          The second list contains the files with different basenames, sorted
+          by uniqueness. (return_all == True)
+        - [str]: A list of files with the best match to the basename of the main
+          file found, sorted by descending match priority. (return_all == False)
+        - []: An empty list if no file with the given extension is found.
         """
         files = [d for d in self._gromacs_files if d.endswith(ext)]
         if len(files) == 0:

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -814,35 +814,39 @@ class GromacsParser(MDParser):
         files = [d for d in self._gromacs_files if d.endswith(ext)]
 
         if len(files) == 0:
-            return ''
+            return None
 
         all_files = {}
-        contain_basename, no_basename_match, counts = [], [], []
+        contain_basename, match_priority, no_basename_match, counts = [], [], [], []
         for f in files:
-            # We assume that the matching trajectory file has (or starts with)
-            # the same basename as the log file, e.g., out.log would correspond to
-            # out.tpr and out.trr and out.edr (or out_some.tpr ...).
-            # These files are therefore given first (second... ) priority in the dictionary.
-            if f.rsplit('.', 1)[0] == self._basename:
+            file_name = f.rsplit('.', 1)[0]
+            # Sort all files with extension `ext` into three priority categories:
+            # 1. files with exact basename match to the main file
+            if file_name == self._basename:
                 all_files[0] = [os.path.join(self._maindir, f)]
-            # ? `a in b` or `b.startswith(a) or b.endswith(a)`? How generic/specific do we want to be?
-            elif self._basename in f.rsplit('.', 1)[0]:
+            # 2. files containing the basename of the main file, order: startswith  > endswith > in
+            elif self._basename in file_name:
+                priority = (
+                    0
+                    if file_name.startswith(self._basename)
+                    else 1
+                    if file_name.endswith(self._basename)
+                    else 2
+                )
+                match_priority.append(priority)
                 contain_basename.append(os.path.join(self._maindir, f))
+            # 3. files with the same extension but no basename match, more unique names get higher priority
             else:
-                # if potential files are named differently, we guess that the ones with a unique name
-                # would be the files we are more likely interested in, and sort the results accordingly
                 count = 0
                 for reff in self._gromacs_files:
-                    if f.rsplit('.', 1)[0] == reff.rsplit('.', 1)[0]:
+                    if file_name == reff.rsplit('.', 1)[0]:
                         count += 1
                 counts.append(count)
                 no_basename_match.append(os.path.join(self._maindir, f))
-        # add the files starting with the same basename in the order they were encountered
+        # add the files containing the same basename sorted by priority
         if contain_basename:
-            all_files[1] = contain_basename
-        # sort files with the correct format, but different basename:
-        # according to the number of other files with the same name
-        # (fewer files with same name: higher priority)
+            all_files[1] = [x for _, x in sorted(zip(match_priority, contain_basename))]
+        # add the files with different basenames sorted by uniqueness
         if no_basename_match:
             all_files[2] = [x for _, x in sorted(zip(counts, no_basename_match))]
 
@@ -1686,8 +1690,8 @@ class GromacsParser(MDParser):
         Test other files only if no true trajectory format with exact or partial
         basename match is found.
 
-        Example: out.log -> out.trr > out_1.trr > 2_out.trr > out.xtc > ... > out.pdb > out.gro
-
+        Example - For out.log: out.trr > out_1.trr > 2_out.trr > 2_out_some.trr > out.xtc
+                               > ... > out.pdb > ... > out.gro > ...
         """
         traj_priority_list = ['trr', 'xtc', 'pdb', 'gro']
 
@@ -1713,11 +1717,11 @@ class GromacsParser(MDParser):
         fallback_files = []
         for file_ext in traj_priority_list:
             results = self.get_all_gromacs_files(file_ext)
+            print(results)
             if results:
                 traj_files_list = [*results.get(0, []), *results.get(1, [])]
                 for file_path in traj_files_list:
                     if is_readable(file_path):
-                        print(file_path)
                         return [file_path]
                 fallback_files.extend(results.get(2, []))
         for file_path in fallback_files:

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -844,7 +844,7 @@ class GromacsParser(MDParser):
             try:
                 thermo_data = self.energy_parser
             except Exception as e:
-                self.logger.warning(f'Error parsing edr file: {e}')
+                self.logger.warning('Error parsing edr file:', exec_info=True)
 
         calculation_times = thermo_data.get('Time', [])
         time_step = self.input_parameters.get('dt')
@@ -1625,7 +1625,7 @@ class GromacsParser(MDParser):
             edr_file = os.path.basename(self.energy_parser.mainfile)
             sec_input_output_files.x_gromacs_inout_file_eneredr = edr_file
         except TypeError:
-            logging.warning(f'Error parsing *.edr file, no energy data available.')
+            logging.warning('Error parsing *.edr file, no energy data available.')
 
         sec_control_parameters = x_gromacs_section_control_parameters()
         sec_run.x_gromacs_section_control_parameters = sec_control_parameters
@@ -1639,44 +1639,29 @@ class GromacsParser(MDParser):
     def find_trajectory_files(self):
         """
         Find and set trajectory files following the priority:
-        "trr" > "xtc" > "pdb" > "gro".
+        "trr" > "xtc", fall back "pdb" > "gro".
         """
 
-        def _get_file_or_fallback(primary_ext, secondary_ext):
-            """Helper function to get primary file, or fallback to secondary."""
-            primary_file = self.get_gromacs_file(primary_ext)
+        def _get_traj_file(ext):
+            primary_file = self.get_gromacs_file(ext)
+            if primary_file is None:
+                return None
             primary_file_nopath = primary_file.rsplit('.', 1)[0]
             primary_file_nopath = primary_file_nopath.rsplit('/')[-1]
-            secondary_file = self.get_gromacs_file(secondary_ext)
-            secondary_file_nopath = secondary_file.rsplit('.', 1)[0]
-            secondary_file_nopath = secondary_file_nopath.rsplit('/')[-1]
+            # Returns a trajectory file with same filename as the mainfile, prevents wrong stage of workflow being used
+            if primary_file_nopath == self._basename:
+                return primary_file
 
-            trajectory_file = None
-
-            if not primary_file_nopath.startswith(self._basename):
-                trajectory_file = (
-                    secondary_file
-                    if secondary_file_nopath.startswith(self._basename)
-                    else primary_file
-                )
+        # Enumerate over copy of list to avoid skipping elements
+        for ext in self.traj_file_priority_list[:]:
+            traj_file = _get_traj_file(ext)
+            if traj_file:
+                return [traj_file]
             else:
-                trajectory_file = primary_file
+                # Remove the missing file format from priority list
+                self.traj_file_priority_list.remove(ext)
 
-            return trajectory_file
-
-        try:
-            # Try to get trr file first, fallback to xtc
-            trajectory_file = _get_file_or_fallback('trr', 'xtc')
-
-            if trajectory_file:
-                return [trajectory_file]
-            else:
-                # Try pdb first, fallback to gro
-                trajectory_file = _get_file_or_fallback('pdb', 'gro')
-                if trajectory_file:
-                    return [trajectory_file]
-        except FileNotFoundError:
-            logging.warning(f'No coordinates found, no visualization possible.')
+        return []
 
     def write_to_archive(self):
         self._maindir = os.path.dirname(self.mainfile)
@@ -1740,16 +1725,49 @@ class GromacsParser(MDParser):
                 )
 
         self.traj_parser.mainfile = topology_file
-        # I have no idea if output trajectory file can be specified in input
+        # JFR comment: I have no idea if output trajectory file can be specified in input
+        # ? Do you mean, e.g., a flag in the *.log file that specifies the output trajectory format?
+        self.traj_file_priority_list = ['trr', 'xtc', 'pdb', 'gro']
         self.traj_parser.auxilliary_files = self.find_trajectory_files()
+        if self.traj_parser.auxilliary_files:
+            # Iterate through available trajectory formats until a valid one is found
+            while self.traj_file_priority_list:
+                # Check if the selected trajectory file can be read properly
+                positions = None
+                if (universe := self.traj_parser.universe) is not None:
+                    atoms = getattr(universe, 'atoms', None)
+                    positions = getattr(atoms, 'positions', None)
 
-        # check to see if the trr file can be read properly (and has positions), otherwise try xtc file instead
-        positions = None
-        if (universe := self.traj_parser.universe) is not None:
-            atoms = getattr(universe, 'atoms', None)
-            positions = getattr(atoms, 'positions', None)
-        if positions is None:
-            self.traj_parser.auxilliary_files = [xtc_file] if xtc_file else [trr_file]
+                if positions is not None:
+                    # A readable, complete trajectory has been found, break the loop
+                    break
+
+                # If positions are None, log a warning
+                self.logger.warning(
+                    'No positions in trajectory file: {}'.format(
+                        self.traj_parser.auxilliary_files[0].split('/')[-1]
+                    )
+                )
+
+                # Remove the failed file format from priority list
+                self.traj_file_priority_list.remove(
+                    self.traj_parser.auxilliary_files[0].split('.')[-1]
+                )
+
+                # Try the next trajectory file format in the priority list
+                if self.traj_file_priority_list:
+                    self.traj_parser.auxilliary_files = self.find_trajectory_files()
+                else:
+                    # If no options are left, log a warning and exit loop
+                    self.logger.error('No valid trajectory files found.')
+                    break
+
+        else:
+            self.logger.error('No recognized trajectory file is part of the upload.')
+            # ! If parsing is not stopped here, it fails in parse_system() due to MDAnalysis universe not being created
+            raise FileNotFoundError(
+                'No recognized trajectory file is part of the upload.'
+            )
 
         self.parse_method()
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -798,19 +798,22 @@ class GromacsParser(MDParser):
         - []: An empty list if no file with the given extension is found.
         """
         files = [d for d in self._gromacs_files if d.endswith(ext)]
-        if len(files) == 0:
-            return []
+        if not files:
+            return [] if not return_all else ([], [], [])
 
-        all_files: Tuple[List, List, List] = ([], [], [])
-        contain_basename, match_priority, no_basename_match, counts = [], [], [], []
+        exact_matches = []
+        contain_basename = []
+        match_priority = []
+        no_basename_match = []
+        counts = []
+
         for f in files:
             filename = f.rsplit('.', 1)[0]
+            filepath = os.path.join(self._maindir, f)
             # Sort all files with extension `ext` into three priority categories:
             # 1. files with exact basename match to the main file
             if filename == self._basename:
-                all_files[0].append(os.path.join(self._maindir, f))
-                if not return_all:
-                    return all_files[0]
+                exact_matches.append(filepath)
             # 2. files containing the basename of the main file, order: startswith  > endswith > in
             elif self._basename in filename:
                 priority = (
@@ -821,29 +824,41 @@ class GromacsParser(MDParser):
                     else 2
                 )
                 match_priority.append(priority)
-                contain_basename.append(os.path.join(self._maindir, f))
+                contain_basename.append(filepath)
             # 3. files with the same extension but no basename match, more unique names get higher priority
             else:
-                count = 0
-                for reff in self._gromacs_files:
-                    if filename == reff.rsplit('.', 1)[0]:
-                        count += 1
+                count = sum(
+                    1
+                    for reff in self._gromacs_files
+                    if filename == reff.rsplit('.', 1)[0]
+                )
                 counts.append(count)
-                no_basename_match.append(os.path.join(self._maindir, f))
+                no_basename_match.append(filepath)
+
+        all_files = ([], [], [])
+
+        if exact_matches:
+            all_files = (exact_matches, [], [])
         # add the files containing the same basename sorted by priority
         if contain_basename:
-            all_files[1].extend(
-                [x for _, x in sorted(zip(match_priority, contain_basename))]
-            )
-            if not return_all:
-                return all_files[1]
+            sorted_contain = [
+                x for _, x in sorted(zip(match_priority, contain_basename))
+            ]
+            all_files = (all_files[0], sorted_contain, [])
         # add the files with different basenames sorted by uniqueness
         if no_basename_match:
-            all_files[2].extend([x for _, x in sorted(zip(counts, no_basename_match))])
-            if not return_all:
-                return all_files[2]
+            sorted_no_match = [x for _, x in sorted(zip(counts, no_basename_match))]
+            all_files = (all_files[0], all_files[1], sorted_no_match)
 
-        return all_files
+        if return_all:
+            return all_files
+
+        # Return first non-empty list among exact, contain, or no basename match
+        for group in all_files:
+            if group:
+                return group
+
+        return []
 
     def parse_thermodynamic_data(self):
         sec_run = self.archive.run[-1]
@@ -1674,48 +1689,52 @@ class GromacsParser(MDParser):
         Example - For out.log: out.trr > out_1.trr > 2_out.trr > 2_out_some.trr > out.xtc
                                > ... > out.pdb > ... > out.gro > ...
         """
-        traj_priority_list = ['trr', 'xtc', 'pdb', 'gro']
+        high_priority_exts = ['trr', 'xtc']
+        low_priority_exts = ['pdb', 'gro']
         failed_files = []
 
         def matches_mainfile(file_path) -> bool:
             """
-            Check if an MDAnalysis universe can be created from the mainfile (topology)
+            Check if a MDAnalysis universe can be created from the mainfile (topology)
             and the current trajectory file.
             """
-            # set the trajectory file to the current file_path,
-            # the traj_parser attempts to create a MDAnalysis universe
             try:
-                print(
-                    f'Checking trajectory file: {file_path} with {self.traj_parser.mainfile}'
-                )
                 u = MDAnalysis.Universe(self.traj_parser.mainfile, file_path)
-                if u.atoms:
-                    return True
+                return bool(u.atoms)
             except Exception as e:
-                # If the trajectory file does not match the topology,
-                # the trajectory file remains None
+                # If the trajectory file does not match the topology, reject it.
                 failed_files.append(file_path)
                 return False
 
+        exact_matches_high, exact_matches_low = [], []
+        contains_matches_high, contains_matches_low = [], []
+        fallback_files = []
+
         # Get all MDAnalysis-compatible trajectory files in self.gromacs_files,
-        # sorted by extension priority (priority_list) and filename.
+        # sorted by extension priority (high_priority_exts, low_priority_exts) and filename.
         # Select matching trajectory with highest priority.
-        exact_matches: List[str] = []
-        contains_files: List[str] = []
-        fallback_files: List[str] = []
-        for file_ext in chain(traj_priority_list[:2], traj_priority_list[2:]):
-            traj_files_tup = self.get_gromacs_files(file_ext, return_all=True)
+        def collect_files(ext, exact_list, contains_list):
+            traj_files_tup = self.get_gromacs_files(ext, return_all=True)
             if traj_files_tup:
-                exact_matches.extend(traj_files_tup[0])
-                contains_files.extend(traj_files_tup[1])
+                exact_list.extend(traj_files_tup[0])
+                contains_list.extend(traj_files_tup[1])
                 fallback_files.extend(traj_files_tup[2])
 
-        # Search list of potentially matching trajectory files.
-        # Immediately return highest priority match.
-        for file_path in exact_matches + contains_files + fallback_files:
-            # Check if the trajectory file matches the mainfile (topology)
+        for ext in high_priority_exts:
+            collect_files(ext, exact_matches_high, contains_matches_high)
+        for ext in low_priority_exts:
+            collect_files(ext, exact_matches_low, contains_matches_low)
+
+        ordered_files = (
+            exact_matches_high
+            + contains_matches_high
+            + exact_matches_low
+            + contains_matches_low
+            + fallback_files
+        )
+
+        for file_path in ordered_files:
             if matches_mainfile(file_path):
-                print(file_path)
                 return file_path
 
         # If no matching trajectory file is found, self.trajectory_parser.auxilliary_files remains default (None,).
@@ -1788,7 +1807,6 @@ class GromacsParser(MDParser):
                 )
 
         self.traj_parser.mainfile = topology_file
-
         self.traj_parser.auxilliary_files = self.find_trajectory_file()
 
         self.parse_method()

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -17,12 +17,11 @@
 # limitations under the License.
 #
 import os
-import sys
 import numpy as np
 import logging
 import re
 import datetime
-from typing import List, Dict
+from typing import List, Dict, Tuple, Union
 
 import panedr
 
@@ -777,14 +776,7 @@ class GromacsParser(MDParser):
             if self.mdp_std_filename in filename:
                 return os.path.join(self._maindir, f)
 
-        return next(
-            (
-                v[0]
-                for v in (self.get_all_gromacs_files(self.mdp_ext) or {}).values()
-                if v
-            ),
-            None,
-        )
+        return self.get_all_gromacs_files(self.mdp_ext)
 
     def get_gromacs_file(self, ext):
         files = [d for d in self._gromacs_files if d.endswith(ext)]
@@ -822,20 +814,34 @@ class GromacsParser(MDParser):
 
         return os.path.join(self._maindir, files[counts.index(min(counts))])
 
-    def get_all_gromacs_files(self, ext):
+    def get_all_gromacs_files(
+        self, ext, return_all=False
+    ) -> Union[Tuple[List[str], List[str]], str, None]:
+        """
+        Tries to find all the Gromacs output files with the given extension.
+        return_all: if True, return all files with the given extension, sorted by basename similarity
+        and uniqueness. If False, return the first file that matches the basename of the main file.
+        Returns:
+            - tuple: A tuple of two lists, the first list contains the files with at least partially
+            the same basename as the main file, the second list contains the files with different
+            basenames, sorted by uniqueness. (return_all == True)
+            - str: the first file that matches the basename of the main file. (return_all == False)
+            - None: if no file with the given extension is found.
+        """
         files = [d for d in self._gromacs_files if d.endswith(ext)]
-
         if len(files) == 0:
             return
 
-        all_files = {}
+        all_files = ([], [])
         contain_basename, match_priority, no_basename_match, counts = [], [], [], []
         for f in files:
             filename = f.rsplit('.', 1)[0]
             # Sort all files with extension `ext` into three priority categories:
             # 1. files with exact basename match to the main file
             if filename == self._basename:
-                all_files[0] = [os.path.join(self._maindir, f)]
+                if not return_all:
+                    return os.path.join(self._maindir, f)
+                all_files[0].append(os.path.join(self._maindir, f))
             # 2. files containing the basename of the main file, order: startswith  > endswith > in
             elif self._basename in filename:
                 priority = (
@@ -857,10 +863,18 @@ class GromacsParser(MDParser):
                 no_basename_match.append(os.path.join(self._maindir, f))
         # add the files containing the same basename sorted by priority
         if contain_basename:
-            all_files[1] = [x for _, x in sorted(zip(match_priority, contain_basename))]
+            contain_basename = [
+                x for _, x in sorted(zip(match_priority, contain_basename))
+            ]
+            if not return_all:
+                return contain_basename[0]
+            all_files[0].extend(contain_basename)
         # add the files with different basenames sorted by uniqueness
         if no_basename_match:
-            all_files[2] = [x for _, x in sorted(zip(counts, no_basename_match))]
+            no_basename_match = [x for _, x in sorted(zip(counts, no_basename_match))]
+            if not return_all:
+                return no_basename_match[0]
+            all_files[1].extend(no_basename_match)
 
         return all_files
 
@@ -871,10 +885,7 @@ class GromacsParser(MDParser):
 
         # TODO read also from ene
         # Make sure *.edr file is part of upload before attempting to parse it.
-        edr_file = next(
-            (v[0] for v in (self.get_all_gromacs_files('edr') or {}).values() if v),
-            None,
-        )
+        edr_file = self.get_all_gromacs_files('edr')
         if edr_file:
             self.energy_parser.keys()
             self.energy_parser.mainfile = edr_file
@@ -1156,10 +1167,7 @@ class GromacsParser(MDParser):
         try:
             n_atoms = self.traj_parser.get('n_atoms', 0)
         except Exception:
-            gro_file = next(
-                (v[0] for v in (self.get_all_gromacs_files('gro') or {}).values() if v),
-                None,
-            )
+            gro_file = self.get_all_gromacs_files('gro')
             self.traj_parser.mainfile = gro_file
             n_atoms = self.traj_parser.get('n_atoms', 0)
         atoms_info = self.traj_parser.get('atoms_info', {})
@@ -1568,10 +1576,7 @@ class GromacsParser(MDParser):
             params_key = 'free_energy_calculation_parameters'
             method[params_key] = self.get_free_energy_calculation_parameters()
 
-            self.xvg_parser.mainfile = next(
-                (v[0] for v in (self.get_all_gromacs_files('xvg') or {}).values() if v),
-                None,
-            )
+            self.xvg_parser.mainfile = self.get_all_gromacs_files('xvg')
             free_energies = self.xvg_parser.get('results')
 
             title = free_energies.get('title', '') if free_energies is not None else ''
@@ -1708,37 +1713,41 @@ class GromacsParser(MDParser):
         traj_priority_list = ['trr', 'xtc', 'pdb', 'gro']
 
         # Check if an MDAnalysis universe can be created from the mainfile and the current trajectory file
+        failed_files = []
+
         def matches_mainfile(file_path):
             # set the trajectory file to the current file_path, the traj_parser attempts to create a universe
             try:
                 self.traj_parser.auxilliary_files = [file_path]
             except Exception as e:
                 # If the trajectory file does not match the topology, the trajectory file remains None
-                self.logger.warning(
-                    'Trajectory file does not match topology: {}, {}'.format(
-                        file_path, e
-                    )
-                )
+                failed_files.append(file_path)
                 return False
             else:
                 return True
 
-        # Get all trajectory files in self.gromacs_files sorted by extension priority (priority_list) and filename,
-        # select matching trajectory with highest priority.
+        # Get all MDAnalysis-compatible trajectory files in self.gromacs_files,
+        # sorted by extension priority (priority_list) and filename.
+        # Select matching trajectory with highest priority.
         fallback_files = []
         for file_ext in traj_priority_list:
-            results = self.get_all_gromacs_files(file_ext)
-            if results:
-                traj_files_list = [*results.get(0, []), *results.get(1, [])]
-                for file_path in traj_files_list:
+            traj_files_tup = self.get_all_gromacs_files(file_ext, return_all=True)
+            if traj_files_tup:
+                for file_path in traj_files_tup[0]:
                     if matches_mainfile(file_path):
                         return
-                fallback_files.extend(results.get(2, []))
+                fallback_files.extend(traj_files_tup[1])
         # Search `fallback_files` only if no higher-priority match was found
         for file_path in fallback_files:
             if matches_mainfile(file_path):
                 return
         # If no matching trajectory file is found, self.trajectory_parser.auxilliary_files remains default (None,).
+        # Mismatched trajectory files are logged as a warning.
+        self.logger.warning(
+            'Trajectory files do not match topology.',
+            # TODO: decide wether returning the offending file is useful.
+            extra={'file_paths': failed_files},
+        )
         return
 
     def write_to_archive(self):
@@ -1752,11 +1761,7 @@ class GromacsParser(MDParser):
         self._frame_rate = None
 
         header = self.log_parser.get('header', {})
-        topology_file = next(
-            (v[0] for v in (self.get_all_gromacs_files('tpr') or {}).values() if v),
-            None,
-        )
-
+        topology_file = self.get_all_gromacs_files('tpr')
         sec_run = Run()
         sec_run.program = Program(
             name='GROMACS',

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -819,18 +819,18 @@ class GromacsParser(MDParser):
         all_files = {}
         contain_basename, match_priority, no_basename_match, counts = [], [], [], []
         for f in files:
-            file_name = f.rsplit('.', 1)[0]
+            filename = f.rsplit('.', 1)[0]
             # Sort all files with extension `ext` into three priority categories:
             # 1. files with exact basename match to the main file
-            if file_name == self._basename:
+            if filename == self._basename:
                 all_files[0] = [os.path.join(self._maindir, f)]
             # 2. files containing the basename of the main file, order: startswith  > endswith > in
-            elif self._basename in file_name:
+            elif self._basename in filename:
                 priority = (
                     0
-                    if file_name.startswith(self._basename)
+                    if filename.startswith(self._basename)
                     else 1
-                    if file_name.endswith(self._basename)
+                    if filename.endswith(self._basename)
                     else 2
                 )
                 match_priority.append(priority)
@@ -839,7 +839,7 @@ class GromacsParser(MDParser):
             else:
                 count = 0
                 for reff in self._gromacs_files:
-                    if file_name == reff.rsplit('.', 1)[0]:
+                    if filename == reff.rsplit('.', 1)[0]:
                         count += 1
                 counts.append(count)
                 no_basename_match.append(os.path.join(self._maindir, f))
@@ -1717,7 +1717,6 @@ class GromacsParser(MDParser):
         fallback_files = []
         for file_ext in traj_priority_list:
             results = self.get_all_gromacs_files(file_ext)
-            print(results)
             if results:
                 traj_files_list = [*results.get(0, []), *results.get(1, [])]
                 for file_path in traj_files_list:

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 import os
+import sys
 import numpy as np
 import logging
 import re
@@ -369,6 +370,8 @@ class GromacsEDRParser(FileParser):
 
     @property
     def length(self):
+        if self.fileedr is None:
+            return None
         return self.fileedr.shape[0]
 
 
@@ -774,7 +777,14 @@ class GromacsParser(MDParser):
             if self.mdp_std_filename in filename:
                 return os.path.join(self._maindir, f)
 
-        return self.get_gromacs_file(self.mdp_ext)
+        return next(
+            (
+                v[0]
+                for v in (self.get_all_gromacs_files(self.mdp_ext) or {}).values()
+                if v
+            ),
+            None,
+        )
 
     def get_gromacs_file(self, ext):
         files = [d for d in self._gromacs_files if d.endswith(ext)]
@@ -816,7 +826,7 @@ class GromacsParser(MDParser):
         files = [d for d in self._gromacs_files if d.endswith(ext)]
 
         if len(files) == 0:
-            return None
+            return
 
         all_files = {}
         contain_basename, match_priority, no_basename_match, counts = [], [], [], []
@@ -861,7 +871,10 @@ class GromacsParser(MDParser):
 
         # TODO read also from ene
         # Make sure *.edr file is part of upload before attempting to parse it.
-        edr_file = self.get_gromacs_file('edr')
+        edr_file = next(
+            (v[0] for v in (self.get_all_gromacs_files('edr') or {}).values() if v),
+            None,
+        )
         if edr_file:
             self.energy_parser.keys()
             self.energy_parser.mainfile = edr_file
@@ -1143,7 +1156,10 @@ class GromacsParser(MDParser):
         try:
             n_atoms = self.traj_parser.get('n_atoms', 0)
         except Exception:
-            gro_file = self.get_gromacs_file('gro')
+            gro_file = next(
+                (v[0] for v in (self.get_all_gromacs_files('gro') or {}).values() if v),
+                None,
+            )
             self.traj_parser.mainfile = gro_file
             n_atoms = self.traj_parser.get('n_atoms', 0)
         atoms_info = self.traj_parser.get('atoms_info', {})
@@ -1552,7 +1568,10 @@ class GromacsParser(MDParser):
             params_key = 'free_energy_calculation_parameters'
             method[params_key] = self.get_free_energy_calculation_parameters()
 
-            self.xvg_parser.mainfile = self.get_gromacs_file('xvg')
+            self.xvg_parser.mainfile = next(
+                (v[0] for v in (self.get_all_gromacs_files('xvg') or {}).values() if v),
+                None,
+            )
             free_energies = self.xvg_parser.get('results')
 
             title = free_energies.get('title', '') if free_energies is not None else ''
@@ -1675,7 +1694,7 @@ class GromacsParser(MDParser):
         )
         sec_control_parameters.m_set(quantity_def, input_parameters)
 
-    def find_trajectory_files(self):
+    def find_trajectory_file(self):
         """
         Find and set trajectory files following the priority:
         "trr" > "xtc", fallback "pdb" > "gro". Prioritize files with exact basename
@@ -1733,8 +1752,10 @@ class GromacsParser(MDParser):
         self._frame_rate = None
 
         header = self.log_parser.get('header', {})
-
-        topology_file = self.get_gromacs_file('tpr')
+        topology_file = next(
+            (v[0] for v in (self.get_all_gromacs_files('tpr') or {}).values() if v),
+            None,
+        )
 
         sec_run = Run()
         sec_run.program = Program(
@@ -1784,7 +1805,8 @@ class GromacsParser(MDParser):
                 )
 
         self.traj_parser.mainfile = topology_file
-        self.find_trajectory_files()
+        # Trajectory file is passed to MDAnalysisParser parser under the hood
+        self.find_trajectory_file()
 
         self.parse_method()
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 import os
-import sys
 import numpy as np
 import logging
 import re
@@ -1783,7 +1782,6 @@ class GromacsParser(MDParser):
 
         self.traj_parser.mainfile = topology_file
         self.traj_parser.auxilliary_files = self.find_trajectory_files()
-        sys.exit()
 
         self.parse_method()
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1685,7 +1685,7 @@ class GromacsParser(MDParser):
             # the traj_parser attempts to create a MDAnalysis universe
             try:
                 print(
-                    f'In matches_mainfile: {self.traj_parser.mainfile}, {file_path}\n'
+                    f'Checking trajectory file: {file_path} with {self.traj_parser.mainfile}'
                 )
                 u = MDAnalysis.Universe(self.traj_parser.mainfile, file_path)
                 if u.atoms:
@@ -1699,42 +1699,28 @@ class GromacsParser(MDParser):
         # Get all MDAnalysis-compatible trajectory files in self.gromacs_files,
         # sorted by extension priority (priority_list) and filename.
         # Select matching trajectory with highest priority.
-        def try_priority_group(traj_priority_group) -> str:
-            contains_files: List[str] = []
-            fallback_files: List[str] = []
-            for file_ext in traj_priority_group:
-                print(f'\nChecking for {file_ext} files...\n')
-                traj_files_tup = self.get_gromacs_files(file_ext, return_all=True)
-                if traj_files_tup:
-                    for file_path in traj_files_tup[0]:
-                        if matches_mainfile(file_path):
-                            return file_path
-                    contains_files.extend(traj_files_tup[1])
-                    fallback_files.extend(traj_files_tup[2])
-            # If no exact filename match was found, check for files containing the mainfile name
-            for file_path in contains_files:
-                if matches_mainfile(file_path):
-                    return file_path
-            # Search `fallback_files` only if no higher-priority match was found
-            for file_path in fallback_files:
-                if matches_mainfile(file_path):
-                    return file_path
-            # No match found in this priority group
-            return ''
+        exact_matches: List[str] = []
+        contains_files: List[str] = []
+        fallback_files: List[str] = []
+        for file_ext in traj_priority_list:
+            traj_files_tup = self.get_gromacs_files(file_ext, return_all=True)
+            if traj_files_tup:
+                exact_matches.extend(traj_files_tup[0])
+                contains_files.extend(traj_files_tup[1])
+                fallback_files.extend(traj_files_tup[2])
 
-        # Check 'trr' and 'xtc' first
-        traj_file = try_priority_group(traj_priority_list[:2])
-        if traj_file:
-            return traj_file
-        # Then check 'pdb' and 'gro'
-        traj_file = try_priority_group(traj_priority_list[2:])
-        if traj_file:
-            return traj_file
+        # Search list of potentially matching trajectory files.
+        # Immediately return highest priority match.
+        for file_path in exact_matches + contains_files + fallback_files:
+            # Check if the trajectory file matches the mainfile (topology)
+            if matches_mainfile(file_path):
+                print(file_path)
+                return file_path
 
         # If no matching trajectory file is found, self.trajectory_parser.auxilliary_files remains default (None,).
         # Mismatched trajectory files are logged as a warning.
         self.logger.warning(
-            'Trajectory files do not match topology.',
+            'Provided trajectory files do not match topology.',
             # TODO: decide wether knowing the mismatched trajectory files is useful for the user.
             extra={'file_paths': failed_files},
         )

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1648,9 +1648,8 @@ class GromacsParser(MDParser):
                 return None
             primary_file_nopath = primary_file.rsplit('.', 1)[0]
             primary_file_nopath = primary_file_nopath.rsplit('/')[-1]
-            # Returns a trajectory file with same filename as the mainfile, prevents wrong stage of workflow being used
-            if primary_file_nopath == self._basename:
-                return primary_file
+
+            return primary_file
 
         # Enumerate over copy of list to avoid skipping elements
         for ext in self.traj_file_priority_list[:]:
@@ -1749,21 +1748,30 @@ class GromacsParser(MDParser):
                     )
                 )
 
-                # Remove the failed file format from priority list
-                self.traj_file_priority_list.remove(
-                    self.traj_parser.auxilliary_files[0].split('.')[-1]
-                )
-
-                # Try the next trajectory file format in the priority list
-                if self.traj_file_priority_list:
+                # Check if other files with the same extension are available, attempt to generate universe from them
+                failed_ext = self.traj_parser.auxilliary_files[0].split('.')[-1]
+                failed_file = self.traj_parser.auxilliary_files[0].split('/')[-1]
+                _files = [f for f in self._gromacs_files if f.endswith(failed_ext)]
+                _files.remove(failed_file)
+                if _files:
+                    self._gromacs_files.remove(failed_file)
+                    # Try the next trajectory file with the same extension
                     self.traj_parser.auxilliary_files = self.find_trajectory_files()
                 else:
-                    # If no options are left, log a warning and exit loop
-                    self.logger.error('No valid trajectory files found.')
-                    # ! If parsing is not stopped here, it fails in parse_system() due to MDAnalysis universe not being created
-                    raise FileNotFoundError(
-                        'No recognized trajectory file is part of the upload.'
+                    # Remove the failed file format from priority list
+                    self.traj_file_priority_list.remove(
+                        self.traj_parser.auxilliary_files[0].split('.')[-1]
                     )
+                    if self.traj_file_priority_list:
+                        # Try the next trajectory file format in the priority list
+                        self.traj_parser.auxilliary_files = self.find_trajectory_files()
+                    else:
+                        # If no options are left, log a warning and exit loop
+                        self.logger.error('No valid trajectory files found.')
+                        # ! If parsing is not stopped here, it fails in parse_system() due to MDAnalysis universe not being created
+                        raise FileNotFoundError(
+                            'No recognized trajectory file is part of the upload.'
+                        )
 
         else:
             self.logger.error('No recognized trajectory file is part of the upload.')

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1711,15 +1711,20 @@ class GromacsParser(MDParser):
         def sort_by_priority(files_dicts):
             # accounting for multiple files starting with the basename (priority 1)
             # we expect each dict to contain the exact basename match (priority 0)
-            n_keys = max([len(d[1]) if d.get(1) else 0 for d in files_dicts]) + 1
+            n_keys = [len(d[1]) if d.get(1) else 0 for d in files_dicts]
+            m_keys = [len(d[2]) if d.get(2) else 0 for d in files_dicts]
             seen_keys = []
             dicts_list = []
-            for d in files_dicts:
+            n_add = 1
+            m_add = sum(n_keys) + 1
+            for d_idx, d in enumerate(files_dicts):
                 for key in d:
                     if key == 1:
-                        d[key] = {idx + 1: val for idx, val in d[key].items()}
+                        d[key] = {idx + n_add: val for idx, val in d[key].items()}
+                        n_add += n_keys[d_idx]
                     if key == 2:
-                        d[key] = {idx + n_keys: val for idx, val in d[key].items()}
+                        d[key] = {idx + m_add: val for idx, val in d[key].items()}
+                        m_add += m_keys[d_idx]
                     dicts_list.append(d.get(key, None))
                     for idx in d[key].keys():
                         if idx not in seen_keys:

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -817,11 +817,11 @@ class GromacsParser(MDParser):
 
         # TODO read also from ene
         edr_file = self.get_gromacs_file('edr')
-        self.energy_parser.mainfile = edr_file
-
-        # get it from edr file
-        if self.energy_parser.keys():
-            thermo_data = self.energy_parser
+        if edr_file:
+            self.energy_parser.mainfile = edr_file
+            # get it from edr file
+            if self.energy_parser.keys():
+                thermo_data = self.energy_parser
         else:
             # try to get it from log file
             steps = self.input_parameters.get('step', [])
@@ -1617,7 +1617,11 @@ class GromacsParser(MDParser):
         trajectory_file = os.path.basename(self.traj_parser.auxilliary_files[0])
         sec_input_output_files.x_gromacs_inout_file_trajtrr = trajectory_file
 
-        edr_file = os.path.basename(self.energy_parser.mainfile)
+        try:
+            edr_file = os.path.basename(self.energy_parser.mainfile)
+        except TypeError:
+            edr_file = None
+
         sec_input_output_files.x_gromacs_inout_file_eneredr = edr_file
 
         sec_control_parameters = x_gromacs_section_control_parameters()
@@ -1628,6 +1632,50 @@ class GromacsParser(MDParser):
             'x_gromacs_all_input_parameters'
         )
         sec_control_parameters.m_set(quantity_def, input_parameters)
+
+    def find_trajectory_files(self):
+        """
+        Find and set trajectory files following the priority:
+        "trr" > "xtc" > "pdb" > "gro".
+        """
+
+        def _get_file_or_fallback(primary_ext, secondary_ext):
+            """Helper function to get primary file, or fallback to secondary."""
+            primary_file = self.get_gromacs_file(primary_ext)
+            primary_file_nopath = primary_file.rsplit('.', 1)[0]
+            primary_file_nopath = primary_file_nopath.rsplit('/')[-1]
+            secondary_file = self.get_gromacs_file(secondary_ext)
+            secondary_file_nopath = secondary_file.rsplit('.', 1)[0]
+            secondary_file_nopath = secondary_file_nopath.rsplit('/')[-1]
+
+            trajectory_file = None
+
+            if not primary_file_nopath.startswith(self._basename):
+                trajectory_file = (
+                    secondary_file
+                    if secondary_file_nopath.startswith(self._basename)
+                    else primary_file
+                )
+            else:
+                trajectory_file = primary_file
+
+            return trajectory_file
+
+        try:
+            # Try to get trr file first, fallback to xtc
+            trajectory_file = _get_file_or_fallback('trr', 'xtc')
+
+            if trajectory_file:
+                return [trajectory_file]
+
+            else:
+                # Try pdb first, fallback to gro
+                trajectory_file = _get_file_or_fallback('pdb', 'gro')
+                if trajectory_file:
+                    return [trajectory_file]
+
+        except FileNotFoundError:
+            logging.warning(f'No coordinates found, no visualization possible.')
 
     def write_to_archive(self):
         self._maindir = os.path.dirname(self.mainfile)
@@ -1690,22 +1738,9 @@ class GromacsParser(MDParser):
                     param.lower() if isinstance(param, str) else param
                 )
 
-        # I have no idea if output trajectory file can be specified in input
-        trr_file = self.get_gromacs_file('trr')
-        trr_file_nopath = trr_file.rsplit('.', 1)[0]
-        trr_file_nopath = trr_file_nopath.rsplit('/')[-1]
-        xtc_file = self.get_gromacs_file('xtc')
-        xtc_file_nopath = xtc_file.rsplit('.', 1)[0]
-        xtc_file_nopath = xtc_file_nopath.rsplit('/')[-1]
-        if not trr_file_nopath.startswith(self._basename):
-            trajectory_file = (
-                xtc_file if xtc_file_nopath.startswith(self._basename) else trr_file
-            )
-        else:
-            trajectory_file = trr_file
-
         self.traj_parser.mainfile = topology_file
-        self.traj_parser.auxilliary_files = [trajectory_file]
+        # I have no idea if output trajectory file can be specified in input
+        self.traj_parser.auxilliary_files = self.find_trajectory_files()
 
         # check to see if the trr file can be read properly (and has positions), otherwise try xtc file instead
         positions = None

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1695,28 +1695,24 @@ class GromacsParser(MDParser):
         """
         traj_priority_list = ['trr', 'xtc', 'pdb', 'gro']
 
-        # Check if the number of particles in the current trajectory file matches
-        # the number of particles in self.mainfile (topology).
+        # Check if an MDAnalysis universe can be created from the mainfile and the current trajectory file
         def matches_mainfile(file_path):
-            positions = None
+            # set the trajectory file to the current file_path, the traj_parser attempts to create a universe
             try:
-                test_universe = MDAnalysis.Universe(
-                    self.traj_parser.mainfile, file_path
-                )
-                atoms = getattr(test_universe, 'atoms', None)
-                positions = getattr(atoms, 'positions', None)
-            except Exception:
+                self.traj_parser.auxilliary_files = [file_path]
+            except Exception as e:
+                # If the trajectory file does not match the topology, the trajectory file remains None
                 self.logger.warning(
-                    'Error reading positions from trajectory file: {}'.format(file_path)
+                    'Trajectory file does not match topology: {}, {}'.format(
+                        file_path, e
+                    )
                 )
-            if positions is not None:
-                # If readable, the correct trajectory has been found
+                return False
+            else:
                 return True
 
-            return False
-
-        # Sort all entries in self.gromacs_files by priority_list and filename match,
-        # return matching trajectory with highest priority.
+        # Get all trajectory files in self.gromacs_files sorted by extension priority (priority_list) and filename,
+        # select matching trajectory with highest priority.
         fallback_files = []
         for file_ext in traj_priority_list:
             results = self.get_all_gromacs_files(file_ext)
@@ -1724,13 +1720,14 @@ class GromacsParser(MDParser):
                 traj_files_list = [*results.get(0, []), *results.get(1, [])]
                 for file_path in traj_files_list:
                     if matches_mainfile(file_path):
-                        return [file_path]
+                        return
                 fallback_files.extend(results.get(2, []))
-        # return the first match from fallback_files only if no higher-priority match was found
+        # Search `fallback_files` only if no higher-priority match was found
         for file_path in fallback_files:
             if matches_mainfile(file_path):
-                return [file_path]
-        return []
+                return
+        # If no matching trajectory file is found, self.trajectory_parser.auxilliary_files remains default (None,).
+        return
 
     def write_to_archive(self):
         self._maindir = os.path.dirname(self.mainfile)
@@ -1794,7 +1791,7 @@ class GromacsParser(MDParser):
                 )
 
         self.traj_parser.mainfile = topology_file
-        self.traj_parser.auxilliary_files = self.find_trajectory_files()
+        self.find_trajectory_files()
 
         self.parse_method()
 

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -1737,14 +1737,11 @@ class GromacsParser(MDParser):
         # Get all MDAnalysis-compatible trajectory files in self.gromacs_files,
         # sorted by extension priority (priority_list) and filename.
         # Select matching trajectory with highest priority.
-        fallback_files: List[str] = []
-
         def try_priority_group(traj_priority_group) -> bool:
             contains_files: List[str] = []
+            fallback_files: List[str] = []
             for file_ext in traj_priority_group:
-                print(file_ext)
                 traj_files_tup = self.get_all_gromacs_files(file_ext, return_all=True)
-                print(traj_files_tup)
                 if traj_files_tup:
                     for file_path in traj_files_tup[0]:
                         if matches_mainfile(file_path):
@@ -1753,6 +1750,10 @@ class GromacsParser(MDParser):
                     fallback_files.extend(traj_files_tup[2])
             # If no exact filename match was found, check for files containing the mainfile name
             for file_path in contains_files:
+                if matches_mainfile(file_path):
+                    return True
+            # Search `fallback_files` only if no higher-priority match was found
+            for file_path in fallback_files:
                 if matches_mainfile(file_path):
                     return True
             # No match found in this priority group
@@ -1765,10 +1766,6 @@ class GromacsParser(MDParser):
         if try_priority_group(traj_priority_list[2:]):
             return None
 
-        # Search `fallback_files` only if no higher-priority match was found
-        for file_path in fallback_files:
-            if matches_mainfile(file_path):
-                return None
         # If no matching trajectory file is found, self.trajectory_parser.auxilliary_files remains default (None,).
         # Mismatched trajectory files are logged as a warning.
         self.logger.warning(

--- a/atomisticparsers/gromacs/parser.py
+++ b/atomisticparsers/gromacs/parser.py
@@ -819,11 +819,14 @@ class GromacsParser(MDParser):
         # Make sure *.edr file is part of upload before attempting to parse it.
         edr_file = self.get_gromacs_file('edr')
         if edr_file:
-            self.energy_parser.mainfile = edr_file
-            # get it from edr file
-            if self.energy_parser.keys():
+            # If the edr file can't be read or there are no keys, an error will be raised by the energy parser
+            try:
+                self.energy_parser.keys()
+                self.energy_parser.mainfile = edr_file
                 thermo_data = self.energy_parser
-        else:
+            except Exception:
+                thermo_data = None
+        if not thermo_data:
             # try to get it from log file
             steps = self.input_parameters.get('step', [])
             thermo_data = dict()
@@ -838,13 +841,6 @@ class GromacsParser(MDParser):
                 info = step.get('step_info', {})
                 thermo_data.setdefault('Time', [None] * n_frames)
                 thermo_data['Time'][n] = info.get('Time', None)
-
-        if not thermo_data:
-            # get it from edr file
-            try:
-                thermo_data = self.energy_parser
-            except Exception as e:
-                self.logger.warning('Error parsing edr file:', exec_info=True)
 
         calculation_times = thermo_data.get('Time', [])
         time_step = self.input_parameters.get('dt')

--- a/atomisticparsers/lammps/parser.py
+++ b/atomisticparsers/lammps/parser.py
@@ -180,11 +180,24 @@ def get_unit(units_type, property_type=None, dimension=3):
             density=ureg.ag / ureg.nm**dimension,
         )
 
+    elif units_type == 'lj':
+        units = dict(
+            mass=1,
+            distance=1,
+            time=1,
+            energy=1,
+            velocity=1,
+            force=1,
+            torque=1,
+            temperature=1,
+            pressure=1,
+            dynamic_viscosity=1,
+            charge=1,
+            dipole=1,
+            electric_field=1,
+            density=1,
+        )
     else:
-        # units = dict(
-        #     mass=1, distance=1, time=1, energy=1, velocity=1, force=1,
-        #     torque=1, temperature=1, pressure=1, dynamic_viscosity=1, charge=1,
-        #     dipole=1, electric_field=1, density=1)
         units = dict()
 
     if property_type:

--- a/atomisticparsers/utils/mdanalysis.py
+++ b/atomisticparsers/utils/mdanalysis.py
@@ -77,7 +77,7 @@ class MDAnalysisParser(FileParser):
                     self.mainfile, *self.auxilliary_files, **self.options
                 )
             except Exception as e:
-                self.logger.error(f'Error creating MDAnalysis universe: {e}')
+                self.logger.error('Error creating MDAnalysis universe:', exc_info=e)
         return self._file_handler
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     "pytest-timeout==1.4.2",
     "pytest-cov==2.7.1",
     "astroid>=2.5.1",
-    'mypy==1.0.1',
+    'mypy>=1.15',
     'ruff>=0.6',
     'typing-extensions>=4.12',
 ]

--- a/tests/test_gromacsparser.py
+++ b/tests/test_gromacsparser.py
@@ -42,6 +42,12 @@ def parser():
     return GromacsParser()
 
 
+# fixture for parser instance that is not shared across tests
+@pytest.fixture(scope='function')
+def isolated_parser():
+    return GromacsParser()
+
+
 def test_md_verbose(parser):
     archive = EntryArchive()
     parser.parse('tests/data/gromacs/fe_test/md.log', archive, None)
@@ -891,44 +897,47 @@ def test_str_to_input_parameters(path: str, input_log_fnm: str, result_json_fnm:
         ('prod', ['test.xtc', 'other.trr', 'unrelated.trr'], 'other.trr'),
     ],
 )
-def test_find_trajectory_file(monkeypatch, parser, basename, files, expected):
+def test_find_trajectory_file(monkeypatch, isolated_parser, basename, files, expected):
     """
     Parametrized test of find_trajectory_file using real suffix and prefix priority rules.
     """
-    archive = {}
-    parser._basename = basename
-    parser._maindir = 'upload'
-    logfile_path = f'{parser._maindir}/{basename}.log'
-    monkeypatch.setattr(parser, 'parse', lambda path, archive, _: None)
-    print(parser._basename)
-    print(parser._maindir)
-    print(parser.traj_parser.mainfile)
-    print(type(parser.traj_parser).__dict__.get('mainfile'))
-    print(
-        [cls for cls in type(parser.traj_parser).__mro__ if 'mainfile' in cls.__dict__]
+
+    # Patch the parse method to avoid actual file parsing
+    monkeypatch.setattr(isolated_parser, 'parse', lambda path, archive, _: None)
+    isolated_parser._basename = basename
+    isolated_parser._maindir = 'upload'
+
+    isolated_parser._gromacs_files = files
+
+    # Need to patch the trajectory parser, otherwise I can't overwrite the 'mainfile' property
+    PatchedParser = type(
+        'PatchedParser',
+        (type(isolated_parser.traj_parser),),
+        {
+            'mainfile': property(
+                lambda self: f'{isolated_parser._maindir}/{isolated_parser._basename}.tpr'
+            )
+        },
     )
 
-    # logfile = f'{parser._maindir}/{basename}.log'
-    # pytest.MonkeyPatch.setattr(
-    #     parser.parse, parser.parse.mainfile, lambda path, archive, logfile: None
-    # )
-    # print(parser.parse.__dict__)
+    # Patch the MDAnalysis Universe to avoid check failing because of non-existing files
+    monkeypatch.setattr(
+        'atomisticparsers.gromacs.parser.MDAnalysis.Universe',
+        lambda top, traj=None: type('MockU', (), {'atoms': [1]})(),
+    )
 
-    # pytest.MonkeyPatch.setattr(
-    #     parser.traj_parser.mainfile,
-    #     parser.traj_parser.mainfile,
-    #     lambda: f'{parser._maindir}/{basename}.tpr',
-    # )
-    parser._gromacs_files = files
+    isolated_parser.traj_parser = PatchedParser()
 
-    print(parser.traj_parser.mainfile)
-    print(parser._gromacs_files)
-
-    parser.find_trajectory_file()
-
-    result = parser.traj_parser.auxilliary_files
-    assert isinstance(result, list), f'Expected list, got {type(result)}'
-    assert len(result) == 1, f'Expected 1 file, got {len(result)}'
-    assert result[0] == os.path.join(parser._maindir, expected), (
-        f'Expected {os.path.join(parser._maindir, expected)}, got {result[0]}'
+    result = isolated_parser.find_trajectory_file()
+    isolated_parser.traj_parser.auxilliary_files = [result]
+    assert isinstance(isolated_parser.traj_parser.auxilliary_files, list), (
+        f'Expected list, got {type(isolated_parser.traj_parser.auxilliary_files)}'
+    )
+    assert len(isolated_parser.traj_parser.auxilliary_files) == 1, (
+        f'Expected 1 file, got {len(isolated_parser.traj_parser.auxilliary_files)}'
+    )
+    assert isolated_parser.traj_parser.auxilliary_files[0] == os.path.join(
+        isolated_parser._maindir, expected
+    ), (
+        f'Expected {os.path.join(isolated_parser._maindir, expected)}, got {isolated_parser.traj_parser.auxilliary_files[0]}'
     )

--- a/tests/test_gromacsparser.py
+++ b/tests/test_gromacsparser.py
@@ -795,12 +795,6 @@ def test_str_to_input_parameters(path: str, input_log_fnm: str, result_json_fnm:
             'other_0_1.trr',
         ),
         ('prod', ['other.gro', 'other.pdb', 'other.xtc'], 'other.xtc'),
-        (
-            'prod',
-            ['other.gro', 'other.pdb', 'other.xtc', 'other_0_1.trr'],
-            'other_0_1.trr',
-        ),
-        ('prod', ['other.gro', 'other.pdb', 'other.xtc'], 'other.xtc'),
         ('prod', ['other.gro', 'other.pdb', 'other_0_1.xtc'], 'other_0_1.xtc'),
         ('prod', ['other.gro', 'other.pdb'], 'other.pdb'),
         ('prod', ['other.gro'], 'other.gro'),

--- a/tests/test_gromacsparser.py
+++ b/tests/test_gromacsparser.py
@@ -550,19 +550,19 @@ def test_str_to_input_parameters(path: str, input_log_fnm: str, result_json_fnm:
                 assert_dict_equal(d1[key], d2[key])
             else:
                 if isinstance(d1[key], (str, bool)):
-                    assert (
-                        d1[key] == d2[key]
-                    ), f"Value mismatch for key '{key}': {d1[key]} != {d2[key]}"
+                    assert d1[key] == d2[key], (
+                        f"Value mismatch for key '{key}': {d1[key]} != {d2[key]}"
+                    )
                 elif isinstance(d1[key], np.ndarray):
-                    assert np.isclose(
-                        d1[key], d2[key]
-                    ).all(), f"Value mismatch for key '{key}': {d1[key]} != {d2[key]}"
+                    assert np.isclose(d1[key], d2[key]).all(), (
+                        f"Value mismatch for key '{key}': {d1[key]} != {d2[key]}"
+                    )
                 elif abs(d1[key]) == float('inf'):
                     assert 'inf' == d2[key] if d1[key] > 0 else '-inf' == d2[key]
                 else:
-                    assert d1[key] == approx(
-                        d2[key]
-                    ), f"Value mismatch for key '{key}': {d1[key]} != {d2[key]}"
+                    assert d1[key] == approx(d2[key]), (
+                        f"Value mismatch for key '{key}': {d1[key]} != {d2[key]}"
+                    )
 
     log_parser = GromacsLogParser()
     log_parser.mainfile = f'{path}/{input_log_fnm}'
@@ -577,3 +577,8 @@ def test_str_to_input_parameters(path: str, input_log_fnm: str, result_json_fnm:
     __ = result.pop('mdp_unique_params')
 
     assert_dict_equal(parsed_parameters, result)
+
+
+def test_find_trajectory_file():
+    # TODO: Implement test cases
+    pass

--- a/tests/test_gromacsparser.py
+++ b/tests/test_gromacsparser.py
@@ -16,10 +16,11 @@
 # limitations under the License.
 #
 
-import pytest
-import numpy as np
 import h5py
 import json
+import numpy as np
+import os
+import pytest
 
 from typing import (
     Any,
@@ -579,6 +580,336 @@ def test_str_to_input_parameters(path: str, input_log_fnm: str, result_json_fnm:
     assert_dict_equal(parsed_parameters, result)
 
 
-def test_find_trajectory_file():
-    # TODO: Implement test cases
-    pass
+@pytest.mark.parametrize(
+    'basename, files, expected',
+    [
+        # === Suffix priority ===
+        ('prod', ['prod.gro', 'prod.pdb', 'prod.xtc', 'prod.trr'], 'prod.trr'),
+        ('prod', ['prod.gro', 'prod.pdb', 'prod.xtc', 'prod_0_1.trr'], 'prod.xtc'),
+        ('prod', ['prod.gro', 'prod.pdb'], 'prod.pdb'),
+        ('prod', ['prod.gro', 'prod_0_1.pdb'], 'prod.gro'),
+        # === Prefix match priority for TRR ===
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'prod.xtc',
+                'test_prod_0_1.trr',
+                'prod_0_1.trr',
+                'test_0_1_prod.trr',
+                'prod.trr',
+            ],
+            'prod.trr',
+        ),
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'test_prod_0_1.trr',
+                'prod_0_1.trr',
+                'test_0_1_prod.trr',
+                'other.trr',
+                'other.xtc',
+            ],
+            'prod_0_1.trr',
+        ),
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'test_prod_0_1.trr',
+                'other_0_1.trr',
+                'test_0_1_prod.trr',
+                'other.trr',
+                'other.xtc',
+            ],
+            'test_0_1_prod.trr',
+        ),
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'test_prod_0_1.trr',
+                'other_0_1.trr',
+                'test_0_1_other.trr',
+                'other.trr',
+                'other.xtc',
+            ],
+            'test_prod_0_1.trr',
+        ),
+        # === Prefix match priority for XTC ===
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'test_prod_0_1.xtc',
+                'prod_0_1.xtc',
+                'test_0_1_prod.xtc',
+                'prod.xtc',
+                'prod_0_1.trr',
+                'other.trr',
+                'other.xtc',
+            ],
+            'prod.xtc',
+        ),
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'test_prod_0_1.xtc',
+                'prod_0_1.xtc',
+                'test_0_1_prod.xtc',
+                'other.trr',
+                'other.xtc',
+            ],
+            'prod_0_1.xtc',
+        ),
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'test_prod_0_1.xtc',
+                'other_0_1.xtc',
+                'test_0_1_prod.xtc',
+                'other.trr',
+                'other.xtc',
+            ],
+            'test_0_1_prod.xtc',
+        ),
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'test_prod_0_1.xtc',
+                'other_0_1.xtc',
+                'test_0_1_other.xtc',
+                'other.trr',
+                'other.xtc',
+            ],
+            'test_prod_0_1.xtc',
+        ),
+        # === Prefix match for PDB ===
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'prod_0_1.pdb',
+                'test_0_1_prod.pdb',
+                'test_prod_0_1.pdb',
+            ],
+            'prod.pdb',
+        ),
+        (
+            'prod',
+            [
+                'other.gro',
+                'other.pdb',
+                'prod_0_1.pdb',
+                'test_0_1_prod.pdb',
+                'test_prod_0_1.pdb',
+            ],
+            'prod_0_1.pdb',
+        ),
+        (
+            'prod',
+            [
+                'other.gro',
+                'other.pdb',
+                'other_0_1.pdb',
+                'test_0_1_prod.pdb',
+                'test_prod_0_1.pdb',
+            ],
+            'test_0_1_prod.pdb',
+        ),
+        (
+            'prod',
+            [
+                'other.gro',
+                'other.pdb',
+                'other_0_1.pdb',
+                'test_0_1_other.pdb',
+                'test_prod_0_1.pdb',
+            ],
+            'test_prod_0_1.pdb',
+        ),
+        # === Prefix match for GRO ===
+        ('prod', ['prod.gro', 'other.pdb', 'prod_0_1.pdb'], 'prod.gro'),
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod_0_1.gro',
+                'test_0_1_prod.gro',
+                'test_prod_0_1.gro',
+                'other.pdb',
+            ],
+            'prod.gro',
+        ),
+        (
+            'prod',
+            [
+                'other.gro',
+                'prod_0_1.gro',
+                'test_0_1_prod.gro',
+                'test_prod_0_1.gro',
+                'other.pdb',
+            ],
+            'prod_0_1.gro',
+        ),
+        (
+            'prod',
+            [
+                'other.gro',
+                'other_0_1.gro',
+                'test_0_1_prod.gro',
+                'test_prod_0_1.gro',
+                'other.pdb',
+            ],
+            'test_0_1_prod.gro',
+        ),
+        (
+            'prod',
+            [
+                'other.gro',
+                'other_0_1.gro',
+                'test_0_1_other.gro',
+                'test_prod_0_1.gro',
+                'other.pdb',
+            ],
+            'test_prod_0_1.gro',
+        ),
+        # === Unrelated fallback ===
+        ('prod', ['other.gro', 'other.pdb', 'other.xtc', 'other.trr'], 'other.trr'),
+        (
+            'prod',
+            ['other.gro', 'other.pdb', 'other.xtc', 'other_0_1.trr'],
+            'other_0_1.trr',
+        ),
+        ('prod', ['other.gro', 'other.pdb', 'other.xtc'], 'other.xtc'),
+        (
+            'prod',
+            ['other.gro', 'other.pdb', 'other.xtc', 'other_0_1.trr'],
+            'other_0_1.trr',
+        ),
+        ('prod', ['other.gro', 'other.pdb', 'other.xtc'], 'other.xtc'),
+        ('prod', ['other.gro', 'other.pdb', 'other_0_1.xtc'], 'other_0_1.xtc'),
+        ('prod', ['other.gro', 'other.pdb'], 'other.pdb'),
+        ('prod', ['other.gro'], 'other.gro'),
+        # === Sorting within multiple equal-priority files ===
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'prod_0_3.xtc',
+                'prod_0_2.xtc',
+                'prod_0_1.xtc',
+                'prod_0_4.xtc',
+                'prod_0_3.trr',
+                'prod_0_2.trr',
+                'prod_0_1.trr',
+                'prod_0_4.trr',
+                'test_prod_0_1.trr',
+                'test_0_1_prod.trr',
+                'other.trr',
+                'other.xtc',
+            ],
+            'prod_0_1.trr',
+        ),
+        (
+            'prod',
+            [
+                'prod.gro',
+                'prod.pdb',
+                'prod_0_3.xtc',
+                'prod_0_2.xtc',
+                'prod_0_1.xtc',
+                'prod_0_4.xtc',
+                'other.trr',
+            ],
+            'prod_0_1.xtc',
+        ),
+        (
+            'prod',
+            [
+                'other.gro',
+                'prod_0_3.pdb',
+                'prod_0_2.pdb',
+                'prod_0_1.pdb',
+                'prod_0_4.pdb',
+            ],
+            'prod_0_1.pdb',
+        ),
+        (
+            'prod',
+            [
+                'other.pdb',
+                'prod_0_3.gro',
+                'prod_0_2.gro',
+                'prod_0_1.gro',
+                'prod_0_4.gro',
+            ],
+            'prod_0_1.gro',
+        ),
+        # === Fallback uniqueness ===
+        (
+            'prod',
+            [
+                'test.trr',
+                'test.log',
+                'test.mdp',
+                'other.trr',
+                'unrelated.trr',
+                'unrelated.log',
+                'unrelated.mdp',
+                'unrelated.tpr',
+                'unrelated.edr',
+            ],
+            'other.trr',
+        ),
+        (
+            'prod',
+            [
+                'unrelated.trr',
+                'unrelated.log',
+                'unrelated.mdp',
+                'unrelated.tpr',
+                'unrelated.edr',
+                'test.trr',
+                'test.log',
+                'test.mdp',
+            ],
+            'test.trr',
+        ),
+        # === Fallback with mixed suffixes ===
+        ('prod', ['test.pdb', 'other.xtc'], 'other.xtc'),
+        ('prod', ['test.gro', 'other.xtc'], 'other.xtc'),
+        ('prod', ['test.pdb', 'other.gro'], 'test.pdb'),
+        ('prod', ['test.xtc', 'other.trr', 'unrelated.trr'], 'other.trr'),
+    ],
+)
+def test_find_trajectory_file_parametrized(parser, basename, files, expected):
+    """
+    Parametrized test of find_trajectory_file using real suffix and prefix priority rules.
+    """
+    parser._basename = basename
+    parser._maindir = 'upload'
+    parser._gromacs_files = files
+
+    parser.find_trajectory_file()
+
+    result = parser.traj_parser.auxilliary_files
+    assert isinstance(result, list), f'Expected list, got {type(result)}'
+    assert len(result) == 1, f'Expected 1 file, got {len(result)}'
+    assert result[0] == os.path.join(parser._maindir, expected), (
+        f'Expected {os.path.join(parser._maindir, expected)}, got {result[0]}'
+    )

--- a/tests/test_gromacsparser.py
+++ b/tests/test_gromacsparser.py
@@ -891,13 +891,18 @@ def test_str_to_input_parameters(path: str, input_log_fnm: str, result_json_fnm:
         ('prod', ['test.xtc', 'other.trr', 'unrelated.trr'], 'other.trr'),
     ],
 )
-def test_find_trajectory_file_parametrized(parser, basename, files, expected):
+def test_find_trajectory_file(parser, basename, files, expected):
     """
     Parametrized test of find_trajectory_file using real suffix and prefix priority rules.
     """
     parser._basename = basename
     parser._maindir = 'upload'
     parser._gromacs_files = files
+
+    # === MOCK: Patch MDAnalysis.Universe to always return a mock with `atoms` truthy ===
+    mock_univ = mocker.patch('MDAnalysis.Universe')
+    mock_univ.return_value.atoms = [1]  # anything truthy
+    # parser.traj_parser.mainfile = os.path.join(parser._maindir, f'{basename}.tpr')
 
     parser.find_trajectory_file()
 

--- a/tests/test_gromacsparser.py
+++ b/tests/test_gromacsparser.py
@@ -891,18 +891,38 @@ def test_str_to_input_parameters(path: str, input_log_fnm: str, result_json_fnm:
         ('prod', ['test.xtc', 'other.trr', 'unrelated.trr'], 'other.trr'),
     ],
 )
-def test_find_trajectory_file(parser, basename, files, expected):
+def test_find_trajectory_file(monkeypatch, parser, basename, files, expected):
     """
     Parametrized test of find_trajectory_file using real suffix and prefix priority rules.
     """
+    archive = {}
     parser._basename = basename
     parser._maindir = 'upload'
+    logfile_path = f'{parser._maindir}/{basename}.log'
+    monkeypatch.setattr(parser, 'parse', lambda path, archive, _: None)
+    print(parser._basename)
+    print(parser._maindir)
+    print(parser.traj_parser.mainfile)
+    print(type(parser.traj_parser).__dict__.get('mainfile'))
+    print(
+        [cls for cls in type(parser.traj_parser).__mro__ if 'mainfile' in cls.__dict__]
+    )
+
+    # logfile = f'{parser._maindir}/{basename}.log'
+    # pytest.MonkeyPatch.setattr(
+    #     parser.parse, parser.parse.mainfile, lambda path, archive, logfile: None
+    # )
+    # print(parser.parse.__dict__)
+
+    # pytest.MonkeyPatch.setattr(
+    #     parser.traj_parser.mainfile,
+    #     parser.traj_parser.mainfile,
+    #     lambda: f'{parser._maindir}/{basename}.tpr',
+    # )
     parser._gromacs_files = files
 
-    # === MOCK: Patch MDAnalysis.Universe to always return a mock with `atoms` truthy ===
-    mock_univ = mocker.patch('MDAnalysis.Universe')
-    mock_univ.return_value.atoms = [1]  # anything truthy
-    # parser.traj_parser.mainfile = os.path.join(parser._maindir, f'{basename}.tpr')
+    print(parser.traj_parser.mainfile)
+    print(parser._gromacs_files)
 
     parser.find_trajectory_file()
 


### PR DESCRIPTION
Added visualization option from a single frame (`*.gro` file or `*.pdb` file).
Parser now ensures an `*.edr` file is present in the upload before attempting to access it, preventing an `AttributeError`.